### PR TITLE
Allow for CxoTime() to get current time in date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Important differences:
 - Conversely, starting with `CxoTime` one can add or subtract a `TimeDelta` or
   any astropy `Quantity` with time units.
 
-- To get the current time replace `DateTime()` with `CxoTime.now()`
-
 The standard built-in Time formats that are available in `CxoTime` are:
 
 Format      |  Example

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -64,6 +64,16 @@ class CxoTime(Time):
     ===========  ==============================
 
     """
+    def __new__(cls, *args, **kwargs):
+        # Handle the case of `CxoTime()` which returns the current time. This is
+        # for compatibility with DateTime.
+        if not args:
+            if not kwargs:
+                args = (None, )
+            else:
+                raise ValueError('cannot supply keyword arguments with no time value')
+        return super().__new__(cls, *args, **kwargs)
+
     def __init__(self, *args, **kwargs):
         if args:
             if args[0].__class__.__name__ == 'DateTime':
@@ -74,6 +84,9 @@ class CxoTime(Time):
                     raise ValueError("must use scale 'utc' for DateTime input")
                 if kwargs.setdefault('format', 'date') != 'date':
                     raise ValueError("must use format 'date' for DateTime input")
+        else:
+            # For `CxoTime()`` return the current time in `date` format.
+            args = (Time.now().yday, )
 
         # If format is supplied and is a DateTime format then require scale='utc'.
         fmt = kwargs.get('format')
@@ -103,6 +116,12 @@ class CxoTime(Time):
             kwargs = kwargs_orig
 
         super(CxoTime, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def now(cls):
+        return cls()
+
+    now.__doc__ = Time.now.__doc__
 
 
 class TimeSecs(TimeCxcSec):

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -10,6 +10,7 @@ import numpy as np
 from .. import CxoTime
 from astropy.time import Time
 from Chandra.Time import DateTime
+import astropy.units as u
 
 
 def test_cxotime_basic():
@@ -35,6 +36,18 @@ def test_cxotime_basic():
 
     with pytest.raises(ValueError):
         t = CxoTime('1998:001:00:00:01.000', scale='tt')
+
+
+@pytest.mark.parametrize('now_method', [CxoTime, CxoTime.now])
+def test_cxotime_now(now_method):
+    ct_now = now_method()
+    t_now = Time.now()
+    assert t_now >= ct_now
+    assert (ct_now - t_now) < 10 * u.s
+
+    with pytest.raises(ValueError,
+                       match='cannot supply keyword arguments with no time value'):
+        CxoTime(scale='utc')
 
 
 def test_cxotime_from_datetime():

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,8 +53,6 @@ The key differences between |CxoTime| and DateTime_ are:
 - Conversely, starting with |CxoTime| one can add or subtract a TimeDelta_ or
   any quantity with time units.
 
-- To get the current time replace ``DateTime()`` with ``CxoTime.now()``
-
 The standard built-in Time formats that are available in |CxoTime| are:
 
 ===========  ==============================


### PR DESCRIPTION
## Description

This allows for `CxoTime()` as a drop-in replacement for `DateTime()`, thus making migration easier. It also overrides the `now()` class method to return the time in `date` format instead of `datetime` as in the `Time` base class.

Generally speaking, new code should use `CxoTime.now()` as being more explicit, but either way is OK.

## Testing

- [x] Passes unit tests on MacOS
- [N/A] Functional testing

You might be interested @jzuhone and @matthewdahmer. 