### PR TITLE
Faster guessing of CxoTime-specific formats

### DIFF
--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -90,7 +90,12 @@ class CxoTime(Time):
 
         # If format is supplied and is a DateTime format then require scale='utc'.
         fmt = kwargs.get('format')
+
+        # Define special formats and the type of vals that are accepted
         fmts_datetime = ('greta', 'secs', 'date', 'frac_year')
+        fmt_dtypes = (np.character, np.number, np.character, np.number)
+
+        # Check that scale=UTC for special formats
         if fmt in fmts_datetime and kwargs.setdefault('scale', 'utc') != 'utc':
             raise ValueError(f"must use scale 'utc' for format '{fmt}''")
 
@@ -99,11 +104,15 @@ class CxoTime(Time):
         if fmt is None and len(args) == 1:
             kwargs_orig = copy(kwargs)
             kwargs['scale'] = 'utc'
+            # Do not make a copy unless specifically set by user
+            kwargs.setdefault('copy', False)
+            # Convert to np.array at this point to get dtype
+            val = np.asarray(args[0])
 
-            # TODO: `val = np.asarray(args[0])`, then check dtype and infer fmt
-            # from first element of `val`
+            for fmt, fmt_dtype in zip(fmts_datetime, fmt_dtypes):
+                if not issubclass(val.dtype.type, fmt_dtype):
+                    continue
 
-            for fmt in fmts_datetime:
                 kwargs['format'] = fmt
                 try:
                     super(CxoTime, self).__init__(*args, **kwargs)

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -91,9 +91,9 @@ class CxoTime(Time):
         # If format is supplied and is a DateTime format then require scale='utc'.
         fmt = kwargs.get('format')
 
-        # Define special formats and the type of vals that are accepted
-        fmts_datetime = ('greta', 'secs', 'date', 'frac_year')
-        fmt_dtypes = (np.character, np.number, np.character, np.number)
+        # Define special formats for guessing and type of accepted vals
+        fmts_datetime = ('greta', 'secs', 'date')
+        fmt_dtypes = (np.character, np.number, np.character)
 
         # Check that scale=UTC for special formats
         if fmt in fmts_datetime and kwargs.setdefault('scale', 'utc') != 'utc':


### PR DESCRIPTION
## Description

When guessing `greta`, `secs`, or `date` format inputs, this requires that the inputs have the right type (string, number, string, respectively). This shaves off some time that would be spent uselessly guessing, and also fixes a collision for times in `secs` that look like a valid `greta` time.  [GRETA times do currently accept a float/int input, following the behavior of MATLAB tools].

## Testing

- [x] Passes unit tests on MacOS (note: tests cover the case of supplying each of the guessed formats without providing the `format` arg.
