### PR TITLE
Much faster parsing in CxoTime and add maude format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ All of these formats use the UTC scale.
 secs        | Seconds since 1998-01-01T00:00:00 (tt)
 date        | YYYY:DDD:hh:mm:ss.ss..
 greta       | YYYYDDD.hhmmsssss
+maude       | YYYYDDDhhmmsssss
 frac_year   | YYYY.fffff
 
 Important differences:

--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -1,26 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from .cxotime import CxoTime
 import ska_helpers
-from astropy import config as _config
 
 __version__ = ska_helpers.get_version(__package__)
-
-
-class Conf(_config.ConfigNamespace):  # noqa
-    """
-    Configuration parameters for `astropy.table`.
-    """
-
-    use_fast_parser = _config.ConfigItem(
-        ['True', 'False', 'force'],
-        "Use fast C parser for supported time strings formats, including ISO, "
-        "ISOT, and YearDayTime. Allowed values are the 'False' (use Python parser),"
-        "'True' (use C parser and fall through to Python parser if fails), and "
-        "'force' (use C parser and raise exception if it fails). Note that the"
-        "options are all strings.")
-
-conf = Conf()  # noqa
-
-from .cxotime import CxoTime  # noqa
 
 
 def test(*args, **kwargs):

--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .cxotime import CxoTime
+from .cxotime import CxoTime  # noqa
 import ska_helpers
 
 __version__ = ska_helpers.get_version(__package__)

--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -1,8 +1,26 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .cxotime import CxoTime  # noqa
 import ska_helpers
+from astropy import config as _config
 
 __version__ = ska_helpers.get_version(__package__)
+
+
+class Conf(_config.ConfigNamespace):  # noqa
+    """
+    Configuration parameters for `astropy.table`.
+    """
+
+    use_fast_parser = _config.ConfigItem(
+        ['True', 'False', 'force'],
+        "Use fast C parser for supported time strings formats, including ISO, "
+        "ISOT, and YearDayTime. Allowed values are the 'False' (use Python parser),"
+        "'True' (use C parser and fall through to Python parser if fails), and "
+        "'force' (use C parser and raise exception if it fails). Note that the"
+        "options are all strings.")
+
+conf = Conf()  # noqa
+
+from .cxotime import CxoTime  # noqa
 
 
 def test(*args, **kwargs):

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -21,7 +21,7 @@ array_1d_double = npct.ndpointer(dtype=np.double, ndim=1, flags='C_CONTIGUOUS')
 array_1d_int = npct.ndpointer(dtype=np.intc, ndim=1, flags='C_CONTIGUOUS')
 
 # load the library, using numpy mechanisms
-libpt = npct.load_library("_parse_times", Path(__file__).parent)
+libpt = npct.load_library("parse_times", Path(__file__).parent)
 
 # Set up the return types and argument types for parse_ymdhms_times()
 # int parse_ymdhms_times(char *times, int n_times, int max_str_len,

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -121,8 +121,8 @@ class CxoTime(Time):
         fmt = kwargs.get('format')
 
         # Define special formats for guessing and type of accepted vals
-        fmts_datetime = ('greta', 'secs', 'date')
-        fmt_dtypes = (np.character, np.number, np.character)
+        fmts_datetime = ('greta', 'secs', 'date', 'maude')
+        fmt_dtypes = (np.character, np.number, np.character, np.character)
 
         # Check that scale=UTC for special formats
         if fmt in fmts_datetime and kwargs.setdefault('scale', 'utc') != 'utc':

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -11,6 +11,8 @@ from astropy.time.utils import day_frac
 from astropy.utils import iers
 from astropy import _erfa as erfa
 
+from cxotime import conf
+
 # For working in Chandra operations, possibly with no network access, we cannot
 # allow auto downloads.
 iers.conf.auto_download = False
@@ -168,14 +170,19 @@ class FastDateParserMixin:
         # If specific input subformat is required then use the Python parser.
         # Also do this if Time format class does not define `use_fast_parser`
         # or if the fast parser is entirely disabled.
-        if self.in_subfmt != '*':
-            self.set_jds_python(self, val1, val2)
+        if (self.in_subfmt != '*'
+                or not self.__class__.__dict__.get('use_fast_parser')
+                or conf.use_fast_parser == 'False'):
+            self.set_jds_python(val1, val2)
         else:
             try:
                 self.set_jds_fast(val1)
             except Exception:
-                # Fall through to the Python parser.
-                self.set_jds_python(self, val1, val2)
+                # Fall through to the Python parser unless fast is forced.
+                if conf.use_fast_parser == 'force':
+                    raise
+                else:
+                    self.set_jds_python(val1, val2)
 
     def set_jds_fast(self, val1):
         """Use fast C parser to parse time strings in val1 and set jd1, jd2"""
@@ -283,6 +290,7 @@ class TimeDate(TimeYearDayTime, FastDateParserMixin):
     name = 'date'
 
     # Class attributes for fast C-parsing
+    use_fast_parser = True
     delims = (0, 0, ord(':'), ord(':'), ord(':'), ord(':'), ord('.'))
     starts = (0, -1, 4, 8, 11, 14, 17)
     stops = (3, -1, 7, 10, 13, 16, -1)
@@ -348,6 +356,7 @@ class TimeGreta(TimeDate, FastDateParserMixin):
     # stops: position where component ends (-1 => continue to end of string)
 
     # Before: yr mon  doy     hour      minute    second    frac
+    use_fast_parser = True
     delims = (0, 0, 0, ord('.'), 0, 0, 0)
     starts = (0, -1, 4, 7, 10, 12, 14)
     stops = (3, -1, 6, 9, 11, 13, -1)
@@ -374,6 +383,11 @@ class TimeGreta(TimeDate, FastDateParserMixin):
             val1.shape = shape
 
         self.set_jds_fast_or_python(val1, val2)
+
+    def set_jds_python(self, val1, val2):
+        # Reformat from YYYYDDD.HHMMSSsss to YYYYDDDHHMMSS.sss
+        val1 = np.array([x[:7] + x[8:14] + '.' + x[14:] for x in val1.flat]).reshape(val1.shape)
+        super().set_jds_python(val1, val2)
 
     def to_value(self, parent=None, **kwargs):
         if self.scale == 'utc':

--- a/cxotime/parse_times.c
+++ b/cxotime/parse_times.c
@@ -1,0 +1,343 @@
+#include <stdio.h>
+#include <string.h>
+
+// ASCII codes for '0' and '9'
+const char char_zero = 48;
+const char char_nine = 57;
+
+int parse_int_from_char_array(char *chars, int str_len,
+                              char delim, int idx0, int idx1,
+                              int *val)
+// Parse integer from positions idx0:idx1 (inclusive) within chars, optionally
+// starting with a delimiter.
+//
+// Example: "2020-01-24"
+//                  ^^^
+//           0123456789
+//
+// int day, status;
+// status = parse_int_from_char_array("2020-01-24", &day, 10, '-', 7, 9);
+//
+// Inputs:
+//  char *chars: time string
+//  int str_len: length of *chars string
+//  char delim: optional character at position idx0 when delim > 0
+//  int idx0: start index for parsing integer
+//  int idx1: stop index (inclusive) for parsing integer
+//
+// Output:
+//  int *val: output value
+//
+// Returns:
+//  int status:
+//    0: OK
+//    1: String ends at the beginning of requested value
+//    2: String ends in the middle of requested value
+//    3: Required delimiter character not found
+//    4: Non-digit found where digit (0-9) required
+{
+    int mult = 1;
+    char digit;
+    char ch;
+
+    // Check if string ends (has 0x00) before str_len. Require that this segment
+    // of the string is entirely contained in the string (idx1 < str_len),
+    // remembering that idx1 is inclusive and counts from 0.
+    if (idx1 < str_len) {
+        for (int i = idx0; i <= idx1; i++) {
+            if (chars[i] == 0) {
+                str_len = i;
+                break;
+            }
+        }
+    }
+    // String ends before the beginning of requested value,
+    // e.g. "2000-01" (str_len=7) for day (idx0=7). This is OK in some
+    // cases, e.g. before hour (2000-01-01).
+    if (idx0 >= str_len) {
+        return 1;
+    }
+
+    // String ends in the middle of requested value. This implies a badly
+    // formatted time.
+    if (idx1 >= str_len) {
+        return 2;
+    }
+
+    // Look for optional delimiter character, e.g. ':' before minute. If delim == 0
+    // then no character is required.
+    if (delim > 0) {
+        // Required start character not found.
+        if (chars[idx0] != delim) {
+            return 3;
+        }
+        idx0 += 1;
+    }
+
+    // Build up the value using reversed digits
+    *val = 0;
+    for (int ii = idx1; ii >= idx0; ii--)
+    {
+        ch = chars[ii];
+        if (ch < char_zero || ch > char_nine) {
+            // Not a digit, implying badly formatted time.
+            return 4;
+        }
+        digit = ch - char_zero;
+        *val += digit * mult;
+        mult *= 10;
+    }
+
+    return 0;
+}
+
+int parse_frac_from_char_array(char *chars, int str_len, char delim, int idx0,
+                               double *val)
+// Parse trailing fraction starting from position idx0 in chars.
+//
+// Example: "2020-01-24T12:13:14.5556"
+//                              ^^^^^
+//           012345678901234567890123
+//
+// int status;
+// float frac;
+// status = parse_frac_from_char_array("2020-01-24T12:13:14.5556", &frac, 24, '.', 19);
+//
+// Inputs:
+//  char *chars: time string
+//  int str_len: length of *chars string
+//  char delim: optional character at position idx0 when delim > 0
+//  int idx0: start index for parsing integer
+//
+// Output:
+//  double *val: output value
+//
+// Returns:
+//  int status:
+//    0: OK
+//    1: String ends at the beginning of requested value
+//    3: Required delimiter character not found
+//    4: Non-digit found where digit (0-9) required
+{
+    double mult = 0.1;
+    char digit;
+    char ch;
+
+    *val = 0.0;
+
+    // String ends at exactly before the beginning of requested fraction.
+    // e.g. "2000-01-01 12:13:14". Fraction value is zero.
+    if (idx0 == str_len) {
+        return 1;
+    }
+
+    // Look for optional delimiter character, e.g. '.' before fraction. If delim == 0
+    // then no character is required. This can happen for unusual formats like
+    // Chandra GRETA time yyyyddd.hhmmssfff.
+    if (delim > 0) {
+        // Required start character not found.
+        if (chars[idx0] != delim) {
+            return 3;
+        }
+        idx0 += 1;
+    }
+
+    for (int ii = idx0; ii < str_len; ii++)
+    {
+        ch = chars[ii];
+        if (ch < char_zero || ch > char_nine) {
+            // Not a digit, implying badly formatted time.
+            return 4;
+        }
+        digit = ch - char_zero;
+        *val += digit * mult;
+        mult /= 10.0;
+    }
+    return 0;
+}
+
+static inline int is_leap_year (int year)
+// Determine if year is a leap year.
+// Inspired by from https://stackoverflow.com/questions/17634282
+{
+  return ((year & 3) == 0)
+          && ((year % 100 != 0)
+              || (((year / 100) & 3) == 0));
+}
+
+int convert_day_of_year_to_month_day(int year, int day_of_year, int *month, int *day_of_month)
+// Convert year and day_of_year into month, day_of_month
+// Inspired by from https://stackoverflow.com/questions/17634282, determine
+{
+    int leap_year = is_leap_year(year) ? 1 : 0;
+    int days_in_year = leap_year ? 366 : 365;
+    const unsigned short int _mon_yday_normal[13] =
+        { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365 };
+    const unsigned short int _mon_yday_leap[13] =
+        { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366 };
+    const unsigned short int *mon_yday = leap_year ? _mon_yday_leap :_mon_yday_normal;
+
+    if (day_of_year < 1 || day_of_year > days_in_year) {
+        // Error in day_of_year
+        return 5;
+    }
+
+    for (int mon = 1; mon <= 12; mon++) {
+        if (day_of_year <= mon_yday[mon]) {
+            *month = mon;
+            *day_of_month = day_of_year - mon_yday[mon - 1];
+            break;
+        }
+    }
+
+    return 0;
+}
+
+int parse_ymdhms_times(char *times, int n_times, int max_str_len, int has_day_of_year,
+                   char *delims, int *starts, int *stops, int *break_allowed,
+                   int *years, int *months, int *days, int *hours,
+                   int *minutes, double *seconds)
+// Parse a string time in `chars` which has year, (month, day | day_of_year),
+// hour, minute, seconds components.
+//
+// Examples: "2020-01-24T12:13:14.5556", "2020:123:12:13:14.5556"
+//
+// Inputs:
+//  char *times: time characters (flattened n_times x max_str_len array)
+//  int n_times: number of time strings (each max_str_len long)
+//  int max_str_len: max length of string (may be null-terminated before this)
+//  int has_day_of_year: time includes day-of-year instead of month, day-of-month
+//  char *delims: array of delimiters preceding yr, mon, day, hr, min, isec, frac
+//      components. Value of 0 means no preceding delimiter.
+//  int *starts, *stop: arrays of start/stop indexes into time string.
+//  int *break_allowed: if true (1) then the time string can legally end just
+//      before the corresponding component (e.g. "2000-01-01" is a valid time but
+//      "2000-01-01 12" is not).
+//
+// Outputs:
+//  int *year, *month, *day, *hour, *minute: output components (n_times long)
+//  double *second: output seconds (n_times long)
+//
+// Returns:
+//  int status:
+//    0: OK
+//    1: String ends at the beginning of requested value
+//    2: String ends in the middle of requested value
+//    3: Required delimiter character not found
+//    4: Non-digit found where digit (0-9) required
+//    5: Bad day of year
+{
+    int str_len;
+    int status = 0;
+    int isec;
+    double frac;
+    char *time;
+    int *year, *month, *day, *hour, *minute;
+    double *second;
+
+    for (int ii = 0; ii < n_times; ii++)
+    {
+        time = times + ii * max_str_len;
+        year = years + ii;
+        month = months + ii;
+        day = days + ii;
+        hour = hours + ii;
+        minute = minutes + ii;
+        second = seconds + ii;
+
+        // Initialize default values
+        *month = 1;
+        *day = 1;
+        *hour = 0;
+        *minute = 0;
+        *second = 0.0;
+
+        // Parse "2000-01-12 13:14:15.678"
+        //        01234567890123456789012
+
+        // Check for null termination before max_str_len. If called using a contiguous
+        // numpy 2-d array of chars there may or may not be null terminations.
+        str_len = max_str_len;
+        for (int i = 0; i < max_str_len; i++) {
+            if (time[i] == 0) {
+                str_len = i;
+                break;
+            }
+        }
+
+        // Get each time component year, month, day, hour, minute, isec, frac
+        status = parse_int_from_char_array(time, str_len, delims[0], starts[0], stops[0], year);
+        if (status) {
+            if (status == 1 && break_allowed[0]) { continue; }
+            else { return status; }
+        }
+
+        // Optionally parse month
+        if (! has_day_of_year) {
+            status = parse_int_from_char_array(time, str_len, delims[1], starts[1], stops[1], month);
+            if (status) {
+                if (status == 1 && break_allowed[1]) { continue; }
+                else { return status; }
+            }
+        }
+
+        // This might be day-of-month or day-of-year
+        status = parse_int_from_char_array(time, str_len, delims[2], starts[2], stops[2], day);
+        if (status) {
+            if (status == 1 && break_allowed[2]) { continue; }
+            else { return status; }
+        }
+
+        if (has_day_of_year) {
+            // day contains day of year at this point, but convert it to day of month
+            status = convert_day_of_year_to_month_day(*year, *day, month, day);
+            if (status) {
+                return status;
+            }
+        }
+
+        status = parse_int_from_char_array(time, str_len, delims[3], starts[3], stops[3], hour);
+        if (status) {
+            if (status == 1 && break_allowed[3]) { continue; }
+            else { return status; }
+        }
+
+        status = parse_int_from_char_array(time, str_len, delims[4], starts[4], stops[4], minute);
+        if (status) {
+            if (status == 1 && break_allowed[4]) { continue; }
+            else { return status; }
+        }
+
+        status = parse_int_from_char_array(time, str_len, delims[5], starts[5], stops[5], &isec);
+        if (status) {
+            if (status == 1 && break_allowed[5]) { continue; }
+            else { return status; }
+        }
+
+        status = parse_frac_from_char_array(time, str_len, delims[6], starts[6], &frac);
+        if (status) {
+            if (status != 1 || ! break_allowed[6]) { return status; }
+        }
+
+        *second = isec + frac;
+    }
+
+    return 0;
+}
+
+int check_unicode(char *chars, int n_unicode_char)
+// Check if *chars is pure ASCII, assuming input is UTF-32
+{
+    char *ch;
+
+    ch = chars;
+    for (int i = 0; i < n_unicode_char; i++)
+    {
+        ch++;
+        if (*ch++) return 1;
+        if (*ch++) return 1;
+        if (*ch++) return 1;
+    }
+    return 0;
+
+}

--- a/cxotime/parse_times.c
+++ b/cxotime/parse_times.c
@@ -1,6 +1,11 @@
 #include <stdio.h>
 #include <string.h>
 
+void PyInit_parse_times(void)
+{
+    /* stub initialization function needed by distutils on Windows */
+}
+
 // ASCII codes for '0' and '9'
 const char char_zero = 48;
 const char char_nine = 57;

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -174,3 +174,17 @@ def test_scale_exception():
 
     with pytest.raises(ValueError, match="must use scale 'utc' for format 'date'"):
         CxoTime('2019:123:12:13:14', format='date', scale='tt')
+
+
+def test_strict_parsing():
+    """Python strptime parsing allows single digits for mon, day, etc.
+
+    CxoTime is stricter in the format requirements.
+    """
+    CxoTime('2000:001:1:2:3', format='yday')
+    with pytest.raises(ValueError, match='Input values did not match the format class date'):
+        CxoTime('2000:001:1:2:3', format='date')
+
+    with pytest.raises(ValueError, match='Input values did not match the format class greta'):
+        CxoTime('2000001.123', format='greta')
+

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -42,8 +42,7 @@ def test_cxotime_basic():
 def test_cxotime_now(now_method):
     ct_now = now_method()
     t_now = Time.now()
-    assert t_now >= ct_now
-    assert (ct_now - t_now) < 10 * u.s
+    assert abs((ct_now - t_now).to_value(u.s)) < 0.1
 
     with pytest.raises(ValueError,
                        match='cannot supply keyword arguments with no time value'):

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -127,12 +127,19 @@ def test_frac_year():
     assert t.frac_year == 2000.5
 
 
-def test_greta():
-    """Test greta format"""
-    t_in = [['2001002.030405678', '2002002.030405678'],
-            ['2003002.030405678', '2004002.030405678']]
+@pytest.mark.parametrize('format', ['maude', 'greta'])
+def test_maude_and_greta(format):
+    """Test maude and greta formats"""
+    def mg(val):
+        if format == 'greta':
+            return val
+        elif format == 'maude':
+            return val[:7] + val[8:]
+
+    t_in = [[mg('2001002.030405678'), mg('2002002.030405678')],
+            [mg('2003002.030405678'), mg('2004002.030405678')]]
     t = CxoTime(t_in)
-    assert t.format == 'greta'
+    assert t.format == format
     assert t.scale == 'utc'
     assert t.shape == (2, 2)
     assert np.all(t.yday == [['2001:002:03:04:05.678', '2002:002:03:04:05.678'],
@@ -140,12 +147,13 @@ def test_greta():
     assert np.all(t.value == t_in)
 
     # Input from float
-    t = CxoTime(np.array(t_in, dtype=np.float), format='greta')
-    assert np.all(t.value == t_in)
+    if format == 'greta':
+        t = CxoTime(np.array(t_in, dtype=np.float), format=format)
+        assert np.all(t.value == t_in)
 
     # During leap second
-    assert CxoTime('2015-06-30 23:59:60.5').greta == '2015181.235960500'
-    assert CxoTime('2015181.235960500').date == '2015:181:23:59:60.500'
+    assert getattr(CxoTime('2015-06-30 23:59:60.5'), format) == mg('2015181.235960500')
+    assert CxoTime(mg('2015181.235960500')).date == '2015:181:23:59:60.500'
 
 
 def test_scale_exception():

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -3,23 +3,17 @@
 Simple test of CxoTime.  The base Time object is extremely well
 tested, so this simply confirms that the add-on in CxoTime works.
 """
+
 import pytest
 import numpy as np
 
-from .. import CxoTime, conf
+from .. import CxoTime
 from astropy.time import Time
 from Chandra.Time import DateTime
 import astropy.units as u
 
 
-@pytest.fixture(scope='module', params=['True', 'False', 'force'])
-def use_fast_parser(request):
-    conf.use_fast_parser = request.param
-    yield
-    conf.use_fast_parser = 'True'
-
-
-def test_cxotime_basic(use_fast_parser):
+def test_cxotime_basic():
     t = CxoTime(1)
     assert t.format == 'secs'
     assert t.scale == 'utc'
@@ -44,15 +38,8 @@ def test_cxotime_basic(use_fast_parser):
         t = CxoTime('1998:001:00:00:01.000', scale='tt')
 
 
-# @pytest.mark.parmetrize('use_fast_parser', ['True', 'False', 'force'])
-# @pytest.mark.parametrize('now_method', [CxoTime, CxoTime.now])
-# def test_cxotime_now(use_fast_parser, now_method):
-#     with conf.set_temp('use_fast_parser', use_fast_parser):
-#         _test_cxotime_basic(now_method)
-
-
 @pytest.mark.parametrize('now_method', [CxoTime, CxoTime.now])
-def test_cxotime_now(use_fast_parser, now_method):
+def test_cxotime_now(now_method):
     ct_now = now_method()
     t_now = Time.now()
     assert t_now >= ct_now
@@ -63,7 +50,7 @@ def test_cxotime_now(use_fast_parser, now_method):
         CxoTime(scale='utc')
 
 
-def test_cxotime_from_datetime(use_fast_parser):
+def test_cxotime_from_datetime():
     secs = DateTime(np.array(['2000:001', '2015:181:23:59:60.500', '2015:180:01:02:03.456'])).secs
     dts = DateTime(secs)
     ct = CxoTime(dts)
@@ -78,7 +65,7 @@ def test_cxotime_from_datetime(use_fast_parser):
             assert np.allclose(vals_out, getattr(dts, out_fmt), atol=1e-4, rtol=0)
 
 
-def test_cxotime_vs_datetime(use_fast_parser):
+def test_cxotime_vs_datetime():
     # Note the bug (https://github.com/sot/Chandra.Time/issues/21), hence the odd first two lines
     # >>> DateTime('2015:181:23:59:60.500').date
     # '2015:182:00:00:00.500'
@@ -101,7 +88,7 @@ def test_cxotime_vs_datetime(use_fast_parser):
                 assert np.allclose(vals_out, vals[out_fmt], atol=1e-4, rtol=0)
 
 
-def test_secs(use_fast_parser):
+def test_secs():
     """
     Test a problem fixed in https://github.com/astropy/astropy/pull/4312.
     This test would pass for ``t = CxoTime(1, scale='tt')`` or if
@@ -112,7 +99,7 @@ def test_secs(use_fast_parser):
     assert np.allclose(t.value, 1.0, atol=1e-10, rtol=0)
 
 
-def test_date(use_fast_parser):
+def test_date():
     t = CxoTime('2001:002:03:04:05.678')
     assert t.format == 'date'
     assert t.scale == 'utc'
@@ -121,7 +108,7 @@ def test_date(use_fast_parser):
     assert CxoTime('2015-06-30 23:59:60.5').date == '2015:181:23:59:60.500'
 
 
-def test_arithmetic(use_fast_parser):
+def test_arithmetic():
     """Very basic test of arithmetic"""
     t1 = CxoTime(0.0)
     t2 = CxoTime(86400.0)
@@ -133,14 +120,14 @@ def test_arithmetic(use_fast_parser):
     assert isinstance(t3, CxoTime)
 
 
-def test_frac_year(use_fast_parser):
+def test_frac_year():
     t = CxoTime(2000.5, format='frac_year')
     assert t.date == '2000:184:00:00:00.000'
     t = CxoTime('2000:184:00:00:00.000')
     assert t.frac_year == 2000.5
 
 
-def test_greta(use_fast_parser):
+def test_greta():
     """Test greta format"""
     t_in = [['2001002.030405678', '2002002.030405678'],
             ['2003002.030405678', '2004002.030405678']]
@@ -161,7 +148,7 @@ def test_greta(use_fast_parser):
     assert CxoTime('2015181.235960500').date == '2015:181:23:59:60.500'
 
 
-def test_scale_exception(use_fast_parser):
+def test_scale_exception():
     with pytest.raises(ValueError, match="must use scale 'utc' for format 'secs'"):
         CxoTime(1, scale='tt')
 

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -3,17 +3,23 @@
 Simple test of CxoTime.  The base Time object is extremely well
 tested, so this simply confirms that the add-on in CxoTime works.
 """
-
 import pytest
 import numpy as np
 
-from .. import CxoTime
+from .. import CxoTime, conf
 from astropy.time import Time
 from Chandra.Time import DateTime
 import astropy.units as u
 
 
-def test_cxotime_basic():
+@pytest.fixture(scope='module', params=['True', 'False', 'force'])
+def use_fast_parser(request):
+    conf.use_fast_parser = request.param
+    yield
+    conf.use_fast_parser = 'True'
+
+
+def test_cxotime_basic(use_fast_parser):
     t = CxoTime(1)
     assert t.format == 'secs'
     assert t.scale == 'utc'
@@ -38,8 +44,15 @@ def test_cxotime_basic():
         t = CxoTime('1998:001:00:00:01.000', scale='tt')
 
 
+# @pytest.mark.parmetrize('use_fast_parser', ['True', 'False', 'force'])
+# @pytest.mark.parametrize('now_method', [CxoTime, CxoTime.now])
+# def test_cxotime_now(use_fast_parser, now_method):
+#     with conf.set_temp('use_fast_parser', use_fast_parser):
+#         _test_cxotime_basic(now_method)
+
+
 @pytest.mark.parametrize('now_method', [CxoTime, CxoTime.now])
-def test_cxotime_now(now_method):
+def test_cxotime_now(use_fast_parser, now_method):
     ct_now = now_method()
     t_now = Time.now()
     assert t_now >= ct_now
@@ -50,7 +63,7 @@ def test_cxotime_now(now_method):
         CxoTime(scale='utc')
 
 
-def test_cxotime_from_datetime():
+def test_cxotime_from_datetime(use_fast_parser):
     secs = DateTime(np.array(['2000:001', '2015:181:23:59:60.500', '2015:180:01:02:03.456'])).secs
     dts = DateTime(secs)
     ct = CxoTime(dts)
@@ -65,7 +78,7 @@ def test_cxotime_from_datetime():
             assert np.allclose(vals_out, getattr(dts, out_fmt), atol=1e-4, rtol=0)
 
 
-def test_cxotime_vs_datetime():
+def test_cxotime_vs_datetime(use_fast_parser):
     # Note the bug (https://github.com/sot/Chandra.Time/issues/21), hence the odd first two lines
     # >>> DateTime('2015:181:23:59:60.500').date
     # '2015:182:00:00:00.500'
@@ -88,7 +101,7 @@ def test_cxotime_vs_datetime():
                 assert np.allclose(vals_out, vals[out_fmt], atol=1e-4, rtol=0)
 
 
-def test_secs():
+def test_secs(use_fast_parser):
     """
     Test a problem fixed in https://github.com/astropy/astropy/pull/4312.
     This test would pass for ``t = CxoTime(1, scale='tt')`` or if
@@ -99,7 +112,7 @@ def test_secs():
     assert np.allclose(t.value, 1.0, atol=1e-10, rtol=0)
 
 
-def test_date():
+def test_date(use_fast_parser):
     t = CxoTime('2001:002:03:04:05.678')
     assert t.format == 'date'
     assert t.scale == 'utc'
@@ -108,7 +121,7 @@ def test_date():
     assert CxoTime('2015-06-30 23:59:60.5').date == '2015:181:23:59:60.500'
 
 
-def test_arithmetic():
+def test_arithmetic(use_fast_parser):
     """Very basic test of arithmetic"""
     t1 = CxoTime(0.0)
     t2 = CxoTime(86400.0)
@@ -120,14 +133,14 @@ def test_arithmetic():
     assert isinstance(t3, CxoTime)
 
 
-def test_frac_year():
+def test_frac_year(use_fast_parser):
     t = CxoTime(2000.5, format='frac_year')
     assert t.date == '2000:184:00:00:00.000'
     t = CxoTime('2000:184:00:00:00.000')
     assert t.frac_year == 2000.5
 
 
-def test_greta():
+def test_greta(use_fast_parser):
     """Test greta format"""
     t_in = [['2001002.030405678', '2002002.030405678'],
             ['2003002.030405678', '2004002.030405678']]
@@ -148,7 +161,7 @@ def test_greta():
     assert CxoTime('2015181.235960500').date == '2015:181:23:59:60.500'
 
 
-def test_scale_exception():
+def test_scale_exception(use_fast_parser):
     with pytest.raises(ValueError, match="must use scale 'utc' for format 'secs'"):
         CxoTime(1, scale='tt')
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ secs      Seconds since 1998-01-01T00:00:00 (TT)       utc
 date      YYYY:DDD:hh:mm:ss.ss..                       utc
 frac_year YYYY.ffffff = date as a floating point year  utc
 greta     YYYYDDD.hhmmsssss                            utc
+maude     YYYYDDDhhmmsssss                             utc
 ========= ===========================================  =======
 
 
@@ -79,6 +80,9 @@ yday         2000:001:00:00:00.000
 
 Examples
 --------
+
+Basic initialization
+^^^^^^^^^^^^^^^^^^^^
 ::
 
   >>> from cxotime import CxoTime
@@ -103,6 +107,19 @@ Examples
 
   >>> t.format
   'date'
+
+Guessing and specifying the format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Generally speaking ``CxoTime`` will successfully guess the format for
+string-based times. However this requires some time, so if you know the
+format in advance then it is recommended to provide this via the ``format``
+argument.
+::
+
+  >>> t = CxoTime('2020001223344555', format='maude')
+  >>> t.date
+  '2020:001:22:33:44.555'
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,8 +28,8 @@ the native Time_ class).
 secs      Seconds since 1998-01-01T00:00:00 (TT)       utc
 date      YYYY:DDD:hh:mm:ss.ss..                       utc
 frac_year YYYY.ffffff = date as a floating point year  utc
-greta     YYYYDDD.hhmmsssss                            utc
-maude     YYYYDDDhhmmsssss                             utc
+greta     YYYYDDD.hhmmsssss (string)                   utc
+maude     YYYYDDDhhmmsssss (integer)                   utc
 ========= ===========================================  =======
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ except ImportError:
 # NOTE: add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
 # to report missed optimizations.
 if sys.platform.startswith('win'):
-    extra_compile_args = ['/DNDEBUG']
+    extra_compile_args = []
     extra_link_args = ['/EXPORT:parse_ymdhms_times', '/EXPORT:check_unicode']
 else:
-    extra_compile_args = ['-UNDEBUG', '-fPIC']
+    extra_compile_args = ['-fPIC']
     extra_link_args = []
 
 # Set up extension for C-based time parser. Numpy is required for build but is

--- a/setup.py
+++ b/setup.py
@@ -10,19 +10,24 @@ except ImportError:
 
 # NOTE: add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
 # to report missed optimizations.
-extra_compile_args = ['-UNDEBUG']
-if not sys.platform.startswith('win'):
-    extra_compile_args.append('-fPIC')
+if sys.platform.startswith('win'):
+    extra_compile_args = ['/DNDEBUG']
+    extra_link_args = ['/EXPORT:parse_ymdhms_times', '/EXPORT:check_unicode']
+else:
+    extra_compile_args = ['-UNDEBUG', '-fPIC']
+    extra_link_args = []
 
 # Set up extension for C-based time parser. Numpy is required for build but is
 # optional for other things like `python setup.py --version`.
 try:
     import numpy
-    ext_modules = [Extension(name='cxotime._parse_times',
+    ext_modules = [Extension(name='cxotime.parse_times',
                              sources=['cxotime/parse_times.c'],
                              extra_compile_args=extra_compile_args,
+                             extra_link_args=extra_link_args,
                              include_dirs=[numpy.get_include()],
-                             language='c')]
+                             language='c'
+                             )]
 except ImportError:
     ext_modules = []
 

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,37 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from setuptools import setup
+import sys
+
+from setuptools import setup, Extension
 
 try:
     from testr.setup_helper import cmdclass
 except ImportError:
     cmdclass = {}
 
+# NOTE: add '-Rpass-missed=.*' to ``extra_compile_args`` when compiling with clang
+# to report missed optimizations.
+extra_compile_args = ['-UNDEBUG']
+if not sys.platform.startswith('win'):
+    extra_compile_args.append('-fPIC')
+
+# Set up extension for C-based time parser. Numpy is required for build but is
+# optional for other things like `python setup.py --version`.
+try:
+    import numpy
+    ext_modules = [Extension(name='cxotime._parse_times',
+                             sources=['cxotime/parse_times.c'],
+                             extra_compile_args=extra_compile_args,
+                             include_dirs=[numpy.get_include()],
+                             language='c')]
+except ImportError:
+    ext_modules = []
+
 setup(name='cxotime',
       author='Tom Aldcroft',
       description='Chandra Time class base on astropy Time',
       author_email='taldcroft@cfa.harvard.edu',
       use_scm_version=True,
+      ext_modules=ext_modules,
       setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       zip_safe=False,
       packages=['cxotime', 'cxotime.tests'],


### PR DESCRIPTION
## Description

This effectively does a backport (or sideways port) of https://github.com/astropy/astropy/pull/10360 to speed up parsing of `date` and `greta` format strings by a factor of about 20 and 50, respectively.

For large arrays, the CxoTime object creation time on my Mac is around 300 ns per time.

This also adds a new `maude` format that is basically `greta` as an int64 without the `.`.  It was easiest/fastest to toss this into the parsing PR.

Some timings:

```
In [15]: dates = ['2001:001:01:23:45.666'] * 1_000_000                                                                   

In [16]: from Chandra.Time import date2secs                                                                              

In [17]: time x = date2secs(dates)                                                                                       
CPU times: user 3.49 s, sys: 22.6 ms, total: 3.52 s
Wall time: 3.52 s

In [18]: time x = DateTime(vals, format='date').secs                                                                     
CPU times: user 8.51 s, sys: 20.5 ms, total: 8.53 s
Wall time: 8.53 s

In [19]: time x = CxoTime(vals, format='date').secs                                                                      
CPU times: user 481 ms, sys: 18.4 ms, total: 500 ms
Wall time: 499 ms

In [20]: gretas = ['2001001.012345666'] * 1_000_000                                                                      

In [21]: time x = DateTime(gretas, format='greta').secs                                                                  
CPU times: user 12.8 s, sys: 15.8 ms, total: 12.8 s
Wall time: 12.8 s

In [22]: time x = CxoTime(gretas, format='greta').secs                                                                   
CPU times: user 468 ms, sys: 27 ms, total: 495 ms
Wall time: 495 ms

In [23]: time x = CxoTime(gretas, format='greta').date                                                                   
CPU times: user 4.97 s, sys: 33.6 ms, total: 5 s
Wall time: 5 s

In [24]: time x = DateTime(gretas, format='greta').date                                                                  
CPU times: user 12.9 s, sys: 27.7 ms, total: 12.9 s
Wall time: 12.9 s
```

## Testing

- [x] Passes unit tests on MacOS, Windows
- [x] Functional testing (new tests)
