### PR TITLE
export astropy units and TimeDelta within cxotime

### DIFF
--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .cxotime import CxoTime  # noqa
+from astropy.time import TimeDelta  # noqa
+from astropy import units  # noqa
 import ska_helpers
 
 __version__ = ska_helpers.get_version(__package__)


### PR DESCRIPTION
## Description

This is a little thing. Basically, It just allows me to do
```python
from cxotime import CxoTime, TimeDelta, units as u
```

instead of 
```python
from cxotime import CxoTime
from astropy.time import TimeDelta
from astropy import units as u
```

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #