### PR TITLE
Remove an extra underscore in PyInit declaration

### DIFF
--- a/cxotime/parse_times.c
+++ b/cxotime/parse_times.c
@@ -5,11 +5,11 @@
 const char char_zero = 48;
 const char char_nine = 57;
 
-// Distutils on Windows automatically exports ``PyInit__parse_times``,
+// Distutils on Windows automatically exports ``PyInit_parse_times``,
 // create dummy to prevent linker complaining about missing symbol.
 // Based on convolution/src/convolve.c.
 #if defined(_MSC_VER)
-void PyInit__parse_times(void)
+void PyInit_parse_times(void)
 {
     return;
 }


### PR DESCRIPTION
## Description

I think I changed the name of `parse_times.c` without re-testing on Windows.

## Testing

- [x] Passes unit tests on Windows (`python setup.py test` that does the build as well)
- [N/A] Functional testing

I didn't test on Mac, but the compiler directive is really just Windows.