### PR TITLE
Fix incompatibility with DateTime init with None

### DIFF
--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -97,14 +97,21 @@ class CxoTime(Time):
     def __new__(cls, *args, **kwargs):
         # Handle the case of `CxoTime()` which returns the current time. This is
         # for compatibility with DateTime.
-        if not args:
+        if not args or (len(args) == 1 and args[0] is None):
             if not kwargs:
+                # Stub in a value for `val` so super()__new__ can run since `val`
+                # is a required positional arg.
                 args = (None, )
             else:
                 raise ValueError('cannot supply keyword arguments with no time value')
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
+        if len(args) == 1 and args[0] is None:
+            # Compatibility with DateTime and allows kwarg default of None with
+            # input casting like `date = CxoTime(date)`.
+            args = ()
+
         if args:
             if args[0].__class__.__name__ == 'DateTime':
                 if len(args) > 1:

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -49,6 +49,16 @@ def test_cxotime_now(now_method):
         CxoTime(scale='utc')
 
 
+def test_cxotime_now_by_none():
+    ct_now = CxoTime(None)
+    t_now = Time.now()
+    assert abs((ct_now - t_now).to_value(u.s)) < 0.1
+
+    with pytest.raises(ValueError,
+                       match='cannot supply keyword arguments with no time value'):
+        CxoTime(None, scale='utc')
+
+
 def test_cxotime_from_datetime():
     secs = DateTime(np.array(['2000:001', '2015:181:23:59:60.500', '2015:180:01:02:03.456'])).secs
     dts = DateTime(secs)


### PR DESCRIPTION
## Description

This fixes an incompatibility with the `DateTime` API that allows `DateTime(None)` to give the current date. This is convenient to allow things like:
```
def func(date=None):
    """Default `date` is NOW"""
    date = CxoTime(date)
    ...
```

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing (new unit test)