### PR TITLE
Astropy 4.2 compatibility: modified "import erfa" statement

### DIFF
--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -12,7 +12,7 @@ from astropy.utils import iers
 # in astropy versions < 4.2, erfa was an astropy private package:
 try:
     import erfa
-except:
+except ModuleNotFoundError:
     from astropy import _erfa as erfa
 
 # For working in Chandra operations, possibly with no network access, we cannot

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -9,7 +9,11 @@ from ctypes import c_int
 from astropy.time import Time, TimeCxcSec, TimeYearDayTime, TimeDecimalYear
 from astropy.time.utils import day_frac
 from astropy.utils import iers
-from astropy import _erfa as erfa
+# in astropy versions < 4.2, erfa was an astropy private package:
+try:
+    import erfa
+except:
+    from astropy import _erfa as erfa
 
 # For working in Chandra operations, possibly with no network access, we cannot
 # allow auto downloads.


### PR DESCRIPTION
## Description

Before astropy version 4.2, `erfa` was provided as a private module in astropy. Since version 4.2, the private module `erfa_` was removed. This PR modifies the import statement to first try the standalone module.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #