### PR TITLE
Ignore ERFA dubious year warning

### DIFF
--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -2,6 +2,7 @@
 import numpy as np
 from copy import copy
 from pathlib import Path
+import warnings
 
 import numpy.ctypeslib as npct
 from ctypes import c_int
@@ -14,6 +15,12 @@ try:
     import erfa
 except ModuleNotFoundError:
     from astropy import _erfa as erfa
+
+# Globally ignore the ERFA dubious year warning that gets emitted for UTC dates
+# either before around 1950 or well after the last known leap second. This
+# warning is conservatively indicating that UTC is not well-defined in those
+# regimes, but we don't care.
+warnings.filterwarnings('ignore', category=erfa.ErfaWarning, message=r'.*dubious year')
 
 # For working in Chandra operations, possibly with no network access, we cannot
 # allow auto downloads.


### PR DESCRIPTION
## Description

This patch sets warnings to globally ignore the ERFA dubious year warning that gets emitted for UTC dates either before around 1950 or well after the last known leap second (e.g. `CxoTime('2099:001')`). This warning is conservatively indicating that UTC is not well-defined in those regimes, but we don't care.

One annoying side effect is that this is really global, meaning that once `cxotime` is imported then it applies also to pure `astropy.time.Time` or any calls to the `erfa` package directly. Another strategy would be to catch these warnings individually in application code where they get emitted. But overall I think this warning is useless in the context of Chandra operations work.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional testing

Prior to the patch running `acisfp_check` produced two ERFA warnings about dubious year. With this patch in place the following is warning free:

```
(ska3-2021.2rc4) ➜ env PYTHONPATH=/Users/aldcroft/git/cxotime acisfp_check \
   --outdir=out \
   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
   --state-builder=sql \
   --run-start=2019:135
```
