### PR TITLE
Add date2secs for fast conversion of Year DOY date to CXC seconds

### DIFF
--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .cxotime import CxoTime  # noqa
+from .cxotime import CxoTime, date2secs  # noqa
 from astropy.time import TimeDelta  # noqa
 from astropy import units  # noqa
 import ska_helpers

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -50,6 +50,77 @@ libpt.check_unicode.restype = c_int
 libpt.check_unicode.argtypes = [array_1d_char, c_int]
 
 
+def date2secs(date):
+    """Fast conversion from year-day-of-year date(s) to CXC seconds
+
+    This is a specialized function that allows for fast conversion of a single
+    date or an array of dates to CXC seconds.  It is intended to be used *ONLY*
+    when the input date is known to be in the correct year-day-of-year format.
+
+    The main use case is for a single date or a few dates. For a large array of
+    dates this is not significantly faster than the equivalent call to
+    ``CxoTime(date).secs``.
+
+    This function will raise an exception if the input date is not in one of
+    these allowed formats:
+    - YYYY:DDD
+    - YYYY:DDD:HH:MM
+    - YYYY:DDD:HH:MM:SS
+    - YYYY:DDD:HH:MM:SS.sss
+
+    :param date: str, list of str, bytes, list of bytes, np.ndarray
+        Input date(s) in an allowed year-day-of-year date format
+    :returns: float, np.ndarray
+        CXC seconds matching dimensions of input date(s)
+    """
+    # This code is adapted from the underlying code in astropy time, with some
+    # of the general-purpose handling and validation removed.
+    from astropy.time.formats import TimeYearDayTime
+    from astropy.time import _parse_times
+
+    # Handle bytes or str input and convert to uint8.  We need to the
+    # dtype _parse_times.dt_u1 instead of uint8, since otherwise it is
+    # not possible to create a gufunc with structured dtype output.
+    # See note about ufunc type resolver in pyerfa/erfa/ufunc.c.templ.
+    date = np.asarray(date)
+    if date.dtype.kind == 'U':
+        # This assumes the input is pure ASCII.
+        val1_uint32 = date.view((np.uint32, date.dtype.itemsize // 4))
+        chars = val1_uint32.astype(_parse_times.dt_u1)
+    else:
+        chars = date.view((_parse_times.dt_u1, date.dtype.itemsize))
+
+    # Call the fast parsing ufunc.
+    time_struct = TimeYearDayTime._fast_parser(chars)
+
+    # Convert time ISO date to jd
+    jd1, jd2, retval = erfa.ufunc.dtf2d(
+        b'UTC',
+        time_struct['year'],
+        time_struct['month'],
+        time_struct['day'],
+        time_struct['hour'],
+        time_struct['minute'],
+        time_struct['second'])
+    if np.any(retval):
+        raise ValueError(f'Error in dtf2d: {retval=}')
+
+    # Transform to TT via TAI
+    jd1, jd2, retval = erfa.ufunc.utctai(jd1, jd2)
+    if np.any(retval):
+        raise ValueError(f'Error in utctai: {retval=}')
+
+    jd1, jd2, retval = erfa.ufunc.taitt(jd1, jd2)
+    if np.any(retval):
+        raise ValueError(f'Error in taitt: {retval=}')
+
+    # Fixed offsets taken from CxoTime(0.0).tt.jd1,2
+    time_from_epoch1 = (jd1 - 2450814.0) * 86400.0
+    time_from_epoch2 = (jd2 - 0.5) * 86400.0
+
+    return time_from_epoch1 + time_from_epoch2
+
+
 class CxoTime(Time):
     """Time class for Chandra analysis that is based on ``astropy.time.Time``.
 

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -51,27 +51,28 @@ libpt.check_unicode.argtypes = [array_1d_char, c_int]
 
 
 def date2secs(date):
-    """Fast conversion from year-day-of-year date(s) to CXC seconds
+    """Fast conversion from Year Day-of-Year date(s) to CXC seconds
 
     This is a specialized function that allows for fast conversion of a single
-    date or an array of dates to CXC seconds.  It is intended to be used *ONLY*
-    when the input date is known to be in the correct year-day-of-year format.
+    date or an array of dates to CXC seconds.  It is intended to be used ONLY
+    when the input date is known to be in the correct Year Day-of-Year format.
 
-    The main use case is for a single date or a few dates. For a large array of
-    dates this is not significantly faster than the equivalent call to
-    ``CxoTime(date).secs``.
+    The main use case is for a single date or a few dates. For a single date
+    this function is about 10 times faster than the equivalent call to
+    ``CxoTime(date).secs``. For a large array of dates (more than about 100)
+    this function is not significantly faster.
 
     This function will raise an exception if the input date is not in one of
     these allowed formats:
+
     - YYYY:DDD
     - YYYY:DDD:HH:MM
     - YYYY:DDD:HH:MM:SS
     - YYYY:DDD:HH:MM:SS.sss
 
-    :param date: str, list of str, bytes, list of bytes, np.ndarray
-        Input date(s) in an allowed year-day-of-year date format
-    :returns: float, np.ndarray
-        CXC seconds matching dimensions of input date(s)
+    :param date: str, list of str, bytes, list of bytes, np.ndarray Input
+        date(s) in an allowed year-day-of-year date format
+    :returns: float, np.ndarray CXC seconds matching dimensions of input date(s)
     """
     # This code is adapted from the underlying code in astropy time, with some
     # of the general-purpose handling and validation removed.

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -219,7 +219,7 @@ def test_date2secs(date):
     t = CxoTime(date)
     t_secs = t.secs
     assert t_secs == date2secs(t.date)  # np.array U
-    assert t_secs == date2secs(np.char.encode(t.date, 'ascii')) # np.array S
+    assert t_secs == date2secs(np.char.encode(t.date, 'ascii'))  # np.array S
     assert t_secs == date2secs(date)  # str
     assert t_secs == date2secs(date.encode('ascii'))  # bytes
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -124,6 +124,31 @@ argument.
 .. toctree::
    :maxdepth: 2
 
+
+Fast conversion of Date to CXC seconds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For fast conversion of an input date or dates in Year Day-of-Year date format,
+the function :func:`~cxotime.cxotime.date2secs` can be used.
+
+This is a specialized function similar to the legacy ``Chandra.Time.date2secs``
+that allows for fast conversion of a single date or an array of dates to CXC
+seconds.  It is intended to be used ONLY when the input date is known to be in
+the correct Year Day-of-Year format.
+
+The main use case is for a single date or a few dates. For a single date this
+function is about 10 times faster than the equivalent call to
+``CxoTime(date).secs``. For a large array of dates (more than about 100) this
+function  is not significantly faster.
+
+This function will raise an exception if the input date is not in one of
+these allowed formats:
+
+- YYYY:DDD
+- YYYY:DDD:HH:MM
+- YYYY:DDD:HH:MM:SS
+- YYYY:DDD:HH:MM:SS.sss
+
 API docs
 --------
 


### PR DESCRIPTION
## Description

For a scalar date, converting to CXC seconds via `CxoTime(date).secs` is slow due to all the general purpose machinery that gets invoked in making a class object and comprehensive validation. This gives about a factor of 10 speed-up.

This PR adds a `date2secs` function that strips out all that machinery and does just the conversion. This is very similar to `Chandra.Time.date2secs`. Differences:
- The Chandra.Time version is still about twice as fast.
- The cxotime version handles more formats e.g. '2001:001'.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing (performance)

```
In [3]: date = '2022:001:01:02:03.333'

In [12]: %timeit CxoTime(date, format='date').secs
323 µs ± 9.22 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [6]: %timeit date2secs(date)
38.5 µs ± 2.18 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [7]: %timeit d2s(date)  # Chandra.Time version
16.7 µs ± 1.85 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```