### PR TITLE
Add secs2date function and speed up date2secs

### DIFF
--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .cxotime import CxoTime, date2secs  # noqa
+from .cxotime import CxoTime, date2secs, secs2date  # noqa
 from astropy.time import TimeDelta  # noqa
 from astropy import units  # noqa
 import ska_helpers

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -94,8 +94,11 @@ def date2secs(date):
     # Call the fast parsing ufunc.
     time_struct = TimeYearDayTime._fast_parser(chars)
 
-    # Convert time ISO date to jd
-    jd1, jd2, retval = erfa.ufunc.dtf2d(
+    # In these ERFA calls ignore the return value since we know jd1, jd2 are OK.
+    # Checking the return value via np.any nearly doubles the function time.
+
+    # Convert time ISO date to jd1, jd2
+    jd1, jd2, _ = erfa.ufunc.dtf2d(
         b'UTC',
         time_struct['year'],
         time_struct['month'],
@@ -103,17 +106,10 @@ def date2secs(date):
         time_struct['hour'],
         time_struct['minute'],
         time_struct['second'])
-    if np.any(retval):
-        raise ValueError(f'Error in dtf2d: {retval=}')
 
     # Transform to TT via TAI
-    jd1, jd2, retval = erfa.ufunc.utctai(jd1, jd2)
-    if np.any(retval):
-        raise ValueError(f'Error in utctai: {retval=}')
-
-    jd1, jd2, retval = erfa.ufunc.taitt(jd1, jd2)
-    if np.any(retval):
-        raise ValueError(f'Error in taitt: {retval=}')
+    jd1, jd2, _ = erfa.ufunc.utctai(jd1, jd2)
+    jd1, jd2, _ = erfa.ufunc.taitt(jd1, jd2)
 
     # Fixed offsets taken from CxoTime(0.0).tt.jd1,2
     time_from_epoch1 = (jd1 - 2450814.0) * 86400.0

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -7,7 +7,7 @@ tested, so this simply confirms that the add-on in CxoTime works.
 import pytest
 import numpy as np
 
-from .. import CxoTime, date2secs
+from .. import CxoTime, date2secs, secs2date
 from astropy.time import Time
 from Chandra.Time import DateTime
 import astropy.units as u
@@ -233,3 +233,28 @@ def test_date2secs(date):
     assert np.all(t_secs == date2secs(dates))  # str
     assert np.all(t_secs == date2secs(np.char.encode(t.date, 'ascii')).tolist())  # bytes
     assert t_secs.shape == date2secs(dates).shape
+
+
+@pytest.mark.parametrize(
+    'date',
+    ['2022:001:01:01:01.123', '1999:001'])
+def test_secs2date(date):
+    t = CxoTime(date)
+    t_secs = t.secs
+    t_date = t.date
+    assert t_date == secs2date(t_secs)  # np.array float64
+    assert t_date == secs2date(float(t_secs))  # Python float
+    assert isinstance(secs2date(t_secs), str)
+
+    date2 = str((t + 20 * u.s).date)
+    date3 = str((t + 40 * u.s).date)
+    dates = [[t_date, date2], [date3, date2]]
+    t = CxoTime(dates)
+    t_secs = t.secs
+    t_date = t.date
+    assert np.all(t_date == secs2date(t_secs))  # np.array float64
+    assert np.all(t_date == secs2date(t_secs.tolist()))  # Python 2-d list
+
+    val = secs2date(t_secs)
+    assert isinstance(val, np.ndarray)
+    assert val.dtype.kind == 'U'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,8 +125,8 @@ argument.
    :maxdepth: 2
 
 
-Fast conversion of Date to CXC seconds
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Fast conversion between Date and CXC seconds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For fast conversion of an input date or dates in Year Day-of-Year date format,
 the function :func:`~cxotime.cxotime.date2secs` can be used.
@@ -148,6 +148,10 @@ these allowed formats:
 - YYYY:DDD:HH:MM
 - YYYY:DDD:HH:MM:SS
 - YYYY:DDD:HH:MM:SS.sss
+
+Conversely, for fast conversion from CXC seconds to Year Day-of-Year date, the
+function :func:`~cxotime.cxotime.secs2date` can be used. For scalar inputs this
+is 15-20 times faster than the equivalent call to ``CxoTime(secs).date``.
 
 API docs
 --------


### PR DESCRIPTION
## Description

By popular demand this brings fast conversion from CXC time to Year Day-of-Year date via a new function `secs2date`.
See #27 for overall motivation.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing

### Functional performance testing

```
>>> from cxotime import CxoTime, secs2date, date2secs
>>> secs = CxoTime('2020:001').secs

>>> %timeit CxoTime(secs, format='secs').date
377 µs ± 3.14 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> %timeit secs2date(secs)
22.1 µs ± 239 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> from Chandra.Time import secs2date as s2d
>>> %timeit s2d(secs)
14.9 µs ± 245 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

The `date2secs` speed-up:
```
# NEW
>>> %timeit date2secs('2020:001')
21.9 µs ± 2.19 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

# PREVIOUS (current master)
>>> %timeit date2secs('2020:001')
38.8 µs ± 2.9 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```


Fixes #5 
