### PR TITLE
Add method and console script to convert time formats

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,12 @@ try:
 except ImportError:
     ext_modules = []
 
+entry_points = {
+    "console_scripts": [
+        "cxotime = cxotime.cxotime:print_time_conversions",
+    ]
+}
+
 setup(name='cxotime',
       author='Tom Aldcroft',
       description='Chandra Time class base on astropy Time',
@@ -42,4 +48,5 @@ setup(name='cxotime',
       packages=['cxotime', 'cxotime.tests'],
       tests_require=['pytest'],
       cmdclass=cmdclass,
+      entry_points=entry_points,
       )


### PR DESCRIPTION
## Description

This provides a convenient way to convert from any input time format to a number of convenient and common output formats. It is accessible both by a `CxoTime` method and a command line script `cxotime`.

```
$ cxotime 2022:001
local       2021 Fri Dec 31 07:00:00 PM EST
iso_local   2021-12-31T19:00:00-05:00      
date        2022:001:00:00:00.000          
cxcsec      757382469.184                  
decimalyear 2022.00000                     
iso         2022-01-01 00:00:00.000        
unix        1640995200.000          
```

## Interface impacts
Adds a new command `cxotime` and a new `CxoTime` method.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Installed this locally with `pip install --user .` and confirmed that it runs and produces the expected output.

```
>>> from cxotime import CxoTime
>>> CxoTime("2022:001").print_conversions()
local       2021 Fri Dec 31 07:00:00 PM EST
iso_local   2021-12-31T19:00:00-05:00      
date        2022:001:00:00:00.000          
cxcsec      757382469.184                  
decimalyear 2022.00000                     
iso         2022-01-01 00:00:00.000        
unix        1640995200.000                 
```

