### PR TITLE
Add generic fast format converters for better performance

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: 3.10
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -3,7 +3,8 @@ import ska_helpers
 from astropy import units  # noqa
 from astropy.time import TimeDelta  # noqa
 
-from .cxotime import CxoTime, CxoTimeLike, date2secs, secs2date  # noqa
+from .cxotime import CxoTime, CxoTimeLike
+from .convert import *  # noqa
 
 __version__ = ska_helpers.get_version(__package__)
 

--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -3,8 +3,8 @@ import ska_helpers
 from astropy import units  # noqa
 from astropy.time import TimeDelta  # noqa
 
-from .cxotime import CxoTime, CxoTimeLike
 from .convert import *  # noqa
+from .cxotime import CxoTime, CxoTimeLike  # noqa: F401
 
 __version__ = ska_helpers.get_version(__package__)
 

--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -101,10 +101,7 @@ def get_format(val):
     return fmt_in, jd1, jd2
 
 
-def convert_jd1_jd2_to_secs(jd1, jd2=None):
-    if jd2 is None:
-        jd2 = 0.0
-
+def convert_jd1_jd2_to_secs(jd1, jd2):
     # Transform to TT via TAI
     jd1, jd2, _ = erfa.ufunc.utctai(jd1, jd2)
     jd1, jd2, _ = erfa.ufunc.taitt(jd1, jd2)
@@ -149,7 +146,7 @@ def convert_maude_to_jd1_jd2(date):
     return jd1, jd2
 
 
-def convert_jd1_jd2_to_greta(jd1, jd2=None):
+def convert_jd1_jd2_to_greta(jd1, jd2):
     date = convert_jd1_jd2_to_date(jd1, jd2)
     # Convert '1997:365:23:58:57.816' to '1997365.235857816'
     #          012345678901234567890
@@ -167,7 +164,7 @@ def convert_jd1_jd2_to_greta(jd1, jd2=None):
     return out
 
 
-def convert_jd1_jd2_to_maude(jd1, jd2=None):
+def convert_jd1_jd2_to_maude(jd1, jd2):
     date = convert_jd1_jd2_to_date(jd1, jd2)
     if isinstance(date, np.ndarray):
         out = np.array(
@@ -184,9 +181,7 @@ def convert_jd1_jd2_to_maude(jd1, jd2=None):
     return out
 
 
-def convert_jd1_jd2_to_jd(jd1, jd2=None):
-    if jd2 is None:
-        jd2 = 0.0
+def convert_jd1_jd2_to_jd(jd1, jd2):
     jd = jd1 + jd2
     return jd
 
@@ -225,9 +220,7 @@ def convert_string_to_jd1_jd2(date, time_format_cls):
     return jd1, jd2
 
 
-def convert_jd1_jd2_to_date(jd1, jd2=None):
-    if jd2 is None:
-        jd2 = np.zeros_like(jd1)
+def convert_jd1_jd2_to_date(jd1, jd2):
     iys, ims, ids, ihmsfs = erfa.d2dtf(b"TT", 3, jd1, jd2)
     ihrs = ihmsfs["h"]
     imins = ihmsfs["m"]

--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -1,0 +1,343 @@
+import datetime
+import functools
+import re
+import sys
+
+import erfa
+import numpy as np
+from astropy.time.formats import TimeYearDayTime, _parse_times
+
+from .cxotime import CxoTime, TimeGreta, TimeMaude
+
+__all__ = ['print_time_conversions', 'convert_time_format']
+
+
+def print_time_conversions():
+    """Interface to entry_point script ``cxotime`` to print time conversions"""
+    date = None if len(sys.argv) == 1 else sys.argv[1]
+    date = CxoTime(date)
+    date.print_conversions()
+
+
+def convert_time_format(val, fmt_out, fmt_in=None):
+    """
+    Convert a time to a different format.
+
+    Parameters
+    ----------
+    val : CxoTimeLike
+        Time value
+    fmt_out : str
+        Output format
+    fmt_in : str
+        Input format (default is to guess)
+
+    Returns
+    -------
+    val_out : str
+        Time string in output format
+    """
+    if fmt_in is not None:
+        jd1, jd2 = globals()[f"convert_{fmt_in}_to_jd1_jd2"](val)
+        out = globals()[f"convert_jd1_jd2_to_{fmt_out}"](jd1, jd2)
+        return out
+
+    # Guess the input format. Returns None if guessing failed.
+    fmt_in, jd1, jd2 = get_format(val, fmt_out)
+
+    if fmt_in == fmt_out:
+        return val
+
+    # Try with the fast converters. If we don't have a fast converter then use CxoTime.
+    out = None
+    try:
+        if jd1 is None:
+            jd1, jd2 = globals()[f"convert_{fmt_in}_to_jd1_jd2"](val)
+        out = globals()[f"convert_jd1_jd2_to_{fmt_out}"](jd1, jd2)
+    except KeyError:
+        tm = CxoTime(val, format=fmt_in)
+        out = getattr(tm, fmt_out)
+
+    return out
+
+
+def get_format(val, fmt_out):
+    fmt_in = None
+    jd1 = None
+    jd2 = None
+
+    if val is None:
+        return fmt_in, jd1, jd2
+
+    val = np.asarray(val)
+
+    # First check for a number or array of numbers, which implies CXC seconds
+    if issubclass(val.dtype.type, np.number):
+        fmt_in = "secs"
+        if fmt_out != "secs":
+            # Same code as _secs2date_scalar but inlined here for speed
+            jd1 = val / 86400.0 + 2450814.5
+            jd2 = 0.0
+            jd1, jd2, _ = erfa.ufunc.tttai(jd1, jd2)
+            jd1, jd2, _ = erfa.ufunc.taiutc(jd1, jd2)
+        return fmt_in, jd1, jd2
+
+    if val.dtype.kind not in ("U", "S"):
+        # No clue, punt this back for generic conversion by CxoTime
+        return fmt_in, jd1, jd2
+
+    convert_funcs = [convert_date_to_jd1_jd2]  # , greta_to_jd1_jd2, maude_to_jd1_jd2]
+    for convert_func in convert_funcs:
+        try:
+            jd1, jd2 = convert_func(val)
+            fmt_in = convert_func.__name__.split("_")[0]
+            break
+        except Exception:
+            pass
+
+    return fmt_in, jd1, jd2
+
+
+def convert_date_to_secs(date):
+    """Fast conversion from Year Day-of-Year date(s) to CXC seconds
+
+    This is a specialized function that allows for fast conversion of a single
+    date or an array of dates to CXC seconds.  It is intended to be used ONLY
+    when the input date is known to be in the correct Year Day-of-Year format.
+
+    The main use case is for a single date or a few dates. For a single date
+    this function is about 10 times faster than the equivalent call to
+    ``CxoTime(date).secs``. For a large array of dates (more than about 100)
+    this function is not significantly faster.
+
+    This function will raise an exception if the input date is not in one of
+    these allowed formats:
+
+    - YYYY:DDD
+    - YYYY:DDD:HH:MM
+    - YYYY:DDD:HH:MM:SS
+    - YYYY:DDD:HH:MM:SS.sss
+
+    :param date: str, list of str, bytes, list of bytes, np.ndarray Input
+        date(s) in an allowed year-day-of-year date format
+    :returns: float, np.ndarray CXC seconds matching dimensions of input date(s)
+    """
+    # This code is adapted from the underlying code in astropy time, with some
+    # of the general-purpose handling and validation removed.
+
+    # Handle bytes or str input and convert to uint8.  We need to the
+    # dtype _parse_times.dt_u1 instead of uint8, since otherwise it is
+    # not possible to create a gufunc with structured dtype output.
+    # See note about ufunc type resolver in pyerfa/erfa/ufunc.c.templ.
+    jd1, jd2 = convert_date_to_jd1_jd2(date)
+    secs = convert_jd1_jd2_to_secs(jd1, jd2)
+    return secs
+
+
+def convert_jd1_jd2_to_secs(jd1, jd2=None):
+    if jd2 is None:
+        jd2 = 0.0
+
+    # Transform to TT via TAI
+    jd1, jd2, _ = erfa.ufunc.utctai(jd1, jd2)
+    jd1, jd2, _ = erfa.ufunc.taitt(jd1, jd2)
+
+    # Fixed offsets taken from CxoTime(0.0).tt.jd1,2
+    time_from_epoch1 = (jd1 - 2450814.0) * 86400.0
+    time_from_epoch2 = (jd2 - 0.5) * 86400.0
+
+    secs = time_from_epoch1 + time_from_epoch2
+    return secs
+
+
+def convert_date_to_jd1_jd2(date):
+    # Performance note: using isinstance(date, np.ndarray) is a few times faster than
+    # date = np.asarrray(date). (64 ns vs 226 ns).
+    if not isinstance(date, np.ndarray):
+        date = np.array(date)
+    jd1, jd2 = convert_string_to_jd1_jd2(date, TimeYearDayTime)
+    return jd1, jd2
+
+
+def convert_greta_to_jd1_jd2(date):
+    if not isinstance(date, np.ndarray):
+        date = np.array(date)
+
+    # Allow for numeric input but reformat as string
+    if date.dtype.kind in ("f", "i"):
+        date = np.array([f"{x:.9f}" for x in date.flat]).reshape(date.shape)
+
+    jd1, jd2 = convert_string_to_jd1_jd2(date, TimeGreta)
+    return jd1, jd2
+
+
+def convert_maude_to_jd1_jd2(date):
+    if not isinstance(date, np.ndarray):
+        date = np.array(date)
+
+    if date.dtype.kind == "i":
+        date = date.astype("S")
+
+    jd1, jd2 = convert_string_to_jd1_jd2(date, TimeMaude)
+    return jd1, jd2
+
+
+def convert_jd1_jd2_to_greta(jd1, jd2=None):
+    date = convert_jd1_jd2_to_date(jd1, jd2)
+    # Convert '1997:365:23:58:57.816' to '1997365.235857816'
+    #          012345678901234567890
+    if isinstance(date, np.ndarray):
+        out = np.array(
+            [
+                x[:4] + x[5:8] + "." + x[9:11] + x[12:14] + x[15:17] + x[18:21]
+                for x in date.flat
+            ]
+        )
+        out.shape = date.shape
+    else:
+        x = date  # 15 ns
+        out = x[:4] + x[5:8] + "." + x[9:11] + x[12:14] + x[15:17] + x[18:21]  # 660 ns
+    return out
+
+
+def convert_jd1_jd2_to_maude(jd1, jd2=None):
+    date = convert_jd1_jd2_to_date(jd1, jd2)
+    if isinstance(date, np.ndarray):
+        out = np.array(
+            [
+                x[:4] + x[5:8] + x[9:11] + x[12:14] + x[15:17] + x[18:21]
+                for x in date.flat
+            ]
+        )
+        out = out.astype("i8")
+        out.shape = date.shape
+    else:
+        x = date
+        out = int(x[:4] + x[5:8] + x[9:11] + x[12:14] + x[15:17] + x[18:21])
+    return out
+
+
+def convert_jd1_jd2_to_jd(jd1, jd2=None):
+    if jd2 is None:
+        jd2 = 0.0
+    jd = jd1 + jd2
+    return jd
+
+
+def convert_jd_to_jd1_jd2(jd):
+    jd1 = jd
+    jd2 = 0.0
+    return jd1, jd2
+
+
+def convert_string_to_jd1_jd2(date, time_format_cls):
+    if date.dtype.kind == "U":
+        # This assumes the input is pure ASCII.
+        val1_uint32 = date.view((np.uint32, date.dtype.itemsize // 4))
+        chars = val1_uint32.astype(_parse_times.dt_u1)
+    else:
+        chars = date.view((_parse_times.dt_u1, date.dtype.itemsize))
+
+    # Call the fast parsing ufunc.
+    time_struct = time_format_cls._fast_parser(chars)
+
+    # In these ERFA calls ignore the return value since we know jd1, jd2 are OK.
+    # Checking the return value via np.any nearly doubles the function time.
+
+    # Convert time ISO date to jd1, jd2
+    jd1, jd2, _ = erfa.ufunc.dtf2d(
+        b"UTC",
+        time_struct["year"],
+        time_struct["month"],
+        time_struct["day"],
+        time_struct["hour"],
+        time_struct["minute"],
+        time_struct["second"],
+    )
+
+    return jd1, jd2
+
+
+def convert_secs_to_date(secs):
+    """Fast conversion from CXC seconds to Year Day-of-Year date(s)
+
+    This is a specialized function that allows for fast conversion of one or
+    more CXC seconds times to Year Day-of-Year format.
+
+    The main use case is for a single date or a few dates. For a single date
+    this function is about 15-20 times faster than the equivalent call to
+    ``CxoTime(secs).date``. For a large array of dates (more than about 100)
+    this function is not significantly faster.
+
+    :param secs: float, list of float, np.ndarray
+        Input time(s) in CXC seconds
+    :returns: str, np.ndarray of str
+        Year Day-of-Year dates matching dimensions of input time(s)
+    """
+    jd1, jd2 = convert_secs_to_jd1_jd2(secs)
+    out = convert_jd1_jd2_to_date(jd1, jd2)
+
+    return out
+
+
+def convert_jd1_jd2_to_date(jd1, jd2=None):
+    if jd2 is None:
+        jd2 = np.zeros_like(jd1)
+    iys, ims, ids, ihmsfs = erfa.d2dtf(b"TT", 3, jd1, jd2)
+    ihrs = ihmsfs["h"]
+    imins = ihmsfs["m"]
+    isecs = ihmsfs["s"]
+    ifracs = ihmsfs["f"]
+
+    if isinstance(jd1, np.ndarray):
+        dates = []
+        for iy, im, id, ihr, imin, isec, ifracsec in np.nditer(
+            [iys, ims, ids, ihrs, imins, isecs, ifracs], flags=["zerosize_ok"]
+        ):
+            yday = datetime.datetime(iy, im, id).timetuple().tm_yday
+            date = f"{iy:4d}:{yday:03d}:{ihr:02d}:{imin:02d}:{isec:02d}.{ifracsec:03d}"
+            dates.append(date)
+
+        out = np.array(dates).reshape(jd1.shape)
+    else:
+        yday = datetime.datetime(iys, ims, ids).timetuple().tm_yday
+        out = f"{iys:4d}:{yday:03d}:{ihrs:02d}:{imins:02d}:{isecs:02d}.{ifracs:03d}"
+
+    return out
+
+
+def convert_secs_to_jd1_jd2(secs):
+    jd2 = 0.0
+    try:
+        jd1 = secs / 86400.0 + 2450814.5
+    except TypeError:
+        # For a list input
+        jd1 = np.array(secs, dtype=np.float64) / 86400.0 + 2450814.5
+
+    # In these ERFA calls ignore the return value since we know jd1, jd2 are OK.
+    # Checking the return value via np.any is quite slow.
+    # Transform TT to UTC via TAI
+    jd1, jd2, _ = erfa.ufunc.tttai(jd1, jd2)
+    jd1, jd2, _ = erfa.ufunc.taiutc(jd1, jd2)
+    return jd1, jd2
+
+
+# Define shortcuts for converters like date2secs or greta2date.
+# Accept each value of globals if it matches the pattern convert_jd1_jd2_to_...
+_formats = [
+    m.group(1)
+    for fmt in list(globals())
+    if (m := re.match(r"convert_jd1_jd2_to_(\w+)", fmt))
+]
+
+
+for fmt1 in _formats:
+    for fmt2 in _formats:
+        print(fmt1, fmt2)
+        if fmt1 != fmt2:
+            name = f"{fmt1}2{fmt2}"
+            func = globals()[name] = functools.partial(
+                convert_time_format, fmt_in=fmt1, fmt_out=fmt2
+            )
+            func.__doc__ = f"Convert time from '{fmt1}' to '{fmt2}'"
+            __all__.append(name)

--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -9,7 +9,7 @@ from astropy.time.formats import TimeYearDayTime, _parse_times
 
 from .cxotime import CxoTime, TimeGreta, TimeMaude
 
-__all__ = ['print_time_conversions', 'convert_time_format']
+__all__ = ["print_time_conversions", "convert_time_format"]
 
 
 def print_time_conversions():
@@ -19,7 +19,7 @@ def print_time_conversions():
     date.print_conversions()
 
 
-def convert_time_format(val, fmt_out, fmt_in=None):
+def convert_time_format(val, fmt_out, *, fmt_in=None):
     """
     Convert a time to a different format.
 
@@ -37,6 +37,9 @@ def convert_time_format(val, fmt_out, fmt_in=None):
     val_out : str
         Time string in output format
     """
+    if fmt_in == fmt_out:
+        return val
+
     if fmt_in is not None:
         jd1, jd2 = globals()[f"convert_{fmt_in}_to_jd1_jd2"](val)
         out = globals()[f"convert_jd1_jd2_to_{fmt_out}"](jd1, jd2)
@@ -86,7 +89,11 @@ def get_format(val, fmt_out):
         # No clue, punt this back for generic conversion by CxoTime
         return fmt_in, jd1, jd2
 
-    convert_funcs = [convert_date_to_jd1_jd2]  # , greta_to_jd1_jd2, maude_to_jd1_jd2]
+    convert_funcs = [
+        convert_date_to_jd1_jd2,
+        convert_greta_to_jd1_jd2,
+        convert_maude_to_jd1_jd2,
+    ]
     for convert_func in convert_funcs:
         try:
             jd1, jd2 = convert_func(val)
@@ -333,7 +340,6 @@ _formats = [
 
 for fmt1 in _formats:
     for fmt2 in _formats:
-        print(fmt1, fmt2)
         if fmt1 != fmt2:
             name = f"{fmt1}2{fmt2}"
             func = globals()[name] = functools.partial(

--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -64,7 +64,21 @@ def convert_time_format(val, fmt_out, *, fmt_in=None):
 
 
 def get_format(val):
-    """Get time format of ``val`` and return jd1, jd2 if available"""
+    """Get time format of ``val`` and return jd1, jd2 if available.
+
+    This infers the time format (e.g. 'secs', 'date', 'greta', 'maude') based on the
+    input ``val``. In some cases inferring the format has the side effect of computing
+    the jd1, jd2 values, so those are returned if available.
+
+    The jd1, jd2 values are the internal representation of time used in the astropy Time
+    class, with jd1 being the integer part and jd2 being the fractional remainder of the
+    date as a float Julian Date.
+
+    :param val: str, float, obj
+        Time value
+    :returns: tuple
+        (format, jd1, jd2)
+    """
     fmt_in = None
     jd1 = None
     jd2 = None

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
 import warnings
 from copy import copy
 from typing import Union
@@ -6,7 +7,7 @@ from typing import Union
 import erfa
 import numpy as np
 import numpy.typing as npt
-from astropy.time import Time, TimeCxcSec, TimeDecimalYear, TimeYearDayTime, TimeJD
+from astropy.time import Time, TimeCxcSec, TimeDecimalYear, TimeJD, TimeYearDayTime
 from astropy.utils import iers
 
 # TODO: use npt.NDArray with numpy 1.21

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import datetime
-import sys
 import warnings
 from copy import copy
 from typing import Union
@@ -23,148 +21,6 @@ warnings.filterwarnings("ignore", category=erfa.ErfaWarning, message=r".*dubious
 # For working in Chandra operations, possibly with no network access, we cannot
 # allow auto downloads.
 iers.conf.auto_download = False
-
-
-def date2secs(date):
-    """Fast conversion from Year Day-of-Year date(s) to CXC seconds
-
-    This is a specialized function that allows for fast conversion of a single
-    date or an array of dates to CXC seconds.  It is intended to be used ONLY
-    when the input date is known to be in the correct Year Day-of-Year format.
-
-    The main use case is for a single date or a few dates. For a single date
-    this function is about 10 times faster than the equivalent call to
-    ``CxoTime(date).secs``. For a large array of dates (more than about 100)
-    this function is not significantly faster.
-
-    This function will raise an exception if the input date is not in one of
-    these allowed formats:
-
-    - YYYY:DDD
-    - YYYY:DDD:HH:MM
-    - YYYY:DDD:HH:MM:SS
-    - YYYY:DDD:HH:MM:SS.sss
-
-    :param date: str, list of str, bytes, list of bytes, np.ndarray Input
-        date(s) in an allowed year-day-of-year date format
-    :returns: float, np.ndarray CXC seconds matching dimensions of input date(s)
-    """
-    # This code is adapted from the underlying code in astropy time, with some
-    # of the general-purpose handling and validation removed.
-    from astropy.time import _parse_times
-    from astropy.time.formats import TimeYearDayTime
-
-    # Handle bytes or str input and convert to uint8.  We need to the
-    # dtype _parse_times.dt_u1 instead of uint8, since otherwise it is
-    # not possible to create a gufunc with structured dtype output.
-    # See note about ufunc type resolver in pyerfa/erfa/ufunc.c.templ.
-    date = np.asarray(date)
-    if date.dtype.kind == "U":
-        # This assumes the input is pure ASCII.
-        val1_uint32 = date.view((np.uint32, date.dtype.itemsize // 4))
-        chars = val1_uint32.astype(_parse_times.dt_u1)
-    else:
-        chars = date.view((_parse_times.dt_u1, date.dtype.itemsize))
-
-    # Call the fast parsing ufunc.
-    time_struct = TimeYearDayTime._fast_parser(chars)
-
-    # In these ERFA calls ignore the return value since we know jd1, jd2 are OK.
-    # Checking the return value via np.any nearly doubles the function time.
-
-    # Convert time ISO date to jd1, jd2
-    jd1, jd2, _ = erfa.ufunc.dtf2d(
-        b"UTC",
-        time_struct["year"],
-        time_struct["month"],
-        time_struct["day"],
-        time_struct["hour"],
-        time_struct["minute"],
-        time_struct["second"],
-    )
-
-    # Transform to TT via TAI
-    jd1, jd2, _ = erfa.ufunc.utctai(jd1, jd2)
-    jd1, jd2, _ = erfa.ufunc.taitt(jd1, jd2)
-
-    # Fixed offsets taken from CxoTime(0.0).tt.jd1,2
-    time_from_epoch1 = (jd1 - 2450814.0) * 86400.0
-    time_from_epoch2 = (jd2 - 0.5) * 86400.0
-
-    return time_from_epoch1 + time_from_epoch2
-
-
-def secs2date(secs):
-    """Fast conversion from CXC seconds to Year Day-of-Year date(s)
-
-    This is a specialized function that allows for fast conversion of one or
-    more CXC seconds times to Year Day-of-Year format.
-
-    The main use case is for a single date or a few dates. For a single date
-    this function is about 15-20 times faster than the equivalent call to
-    ``CxoTime(secs).date``. For a large array of dates (more than about 100)
-    this function is not significantly faster.
-
-    :param secs: float, list of float, np.ndarray
-        Input time(s) in CXC seconds
-    :returns: str, np.ndarray of str
-        Year Day-of-Year dates matching dimensions of input time(s)
-    """
-    # This code is adapted from the underlying code in astropy time, with some
-    # of the general-purpose handling and validation removed.
-
-    # For scalars use a specialized version that is about 30% faster.
-    if isinstance(secs, float) or isinstance(secs, np.ndarray) and secs.shape == ():
-        return _secs2date_scalar(secs)
-
-    secs = np.asarray(secs, dtype=np.float64)
-    jd1 = secs / 86400.0 + 2450814.5
-    jd2 = 0.0
-
-    # In these ERFA calls ignore the return value since we know jd1, jd2 are OK.
-    # Checking the return value via np.any is quite slow.
-    # Transform TT to UTC via TAI
-    jd1, jd2, _ = erfa.ufunc.tttai(jd1, jd2)
-    jd1, jd2, _ = erfa.ufunc.taiutc(jd1, jd2)
-
-    dates = []
-    iys, ims, ids, ihmsfs = erfa.d2dtf(b"TT", 3, jd1, jd2)
-    ihrs = ihmsfs["h"]
-    imins = ihmsfs["m"]
-    isecs = ihmsfs["s"]
-    ifracs = ihmsfs["f"]
-    for iy, im, id, ihr, imin, isec, ifracsec in np.nditer(
-        [iys, ims, ids, ihrs, imins, isecs, ifracs], flags=["zerosize_ok"]
-    ):
-        yday = datetime.datetime(iy, im, id).timetuple().tm_yday
-        date = f"{iy:4d}:{yday:03d}:{ihr:02d}:{imin:02d}:{isec:02d}.{ifracsec:03d}"
-        dates.append(date)
-
-    out = np.array(dates).reshape(secs.shape)
-    return out
-
-
-def _secs2date_scalar(secs):
-    """Internal version of secs2date for scalar input
-
-    Same as secs2date but with the array handling removed. This is around 30%
-    faster.
-    """
-    jd1 = secs / 86400.0 + 2450814.5
-    jd2 = 0.0
-
-    jd1, jd2, _ = erfa.ufunc.tttai(jd1, jd2)
-    jd1, jd2, _ = erfa.ufunc.taiutc(jd1, jd2)
-
-    iy, im, id, ihmsfs = erfa.d2dtf(b"TT", 3, jd1, jd2)
-    ihr = ihmsfs["h"]
-    imin = ihmsfs["m"]
-    isec = ihmsfs["s"]
-    ifracsec = ihmsfs["f"]
-    yday = datetime.datetime(iy, im, id).timetuple().tm_yday
-    date = f"{iy:4d}:{yday:03d}:{ihr:02d}:{imin:02d}:{isec:02d}.{ifracsec:03d}"
-
-    return date
 
 
 class CxoTime(Time):
@@ -232,10 +88,21 @@ class CxoTime(Time):
                 # is a required positional arg.
                 args = (None,)
             else:
-                raise ValueError("cannot supply keyword arguments with no time value")
+                raise ValueError('cannot supply keyword arguments with no time value')
+
+        if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
+            # If input is already a CxoTime instance and no other kwargs just return
+            # the instance. Note that copy=False is the default.
+            return args[0]
+
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
+            # If input is already a CxoTime instance and no other kwargs (which
+            # implies copy=False) then no other initialization is needed.
+            return
+
         if len(args) == 1 and args[0] is None:
             # Compatibility with DateTime and allows kwarg default of None with
             # input casting like `date = CxoTime(date)`.

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -6,7 +6,7 @@ from typing import Union
 import erfa
 import numpy as np
 import numpy.typing as npt
-from astropy.time import Time, TimeCxcSec, TimeDecimalYear, TimeYearDayTime
+from astropy.time import Time, TimeCxcSec, TimeDecimalYear, TimeYearDayTime, TimeJD
 from astropy.utils import iers
 
 # TODO: use npt.NDArray with numpy 1.21
@@ -88,7 +88,7 @@ class CxoTime(Time):
                 # is a required positional arg.
                 args = (None,)
             else:
-                raise ValueError('cannot supply keyword arguments with no time value')
+                raise ValueError("cannot supply keyword arguments with no time value")
 
         if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
             # If input is already a CxoTime instance and no other kwargs just return
@@ -245,6 +245,16 @@ class CxoTime(Time):
         return out
 
 
+TimeJD.convert_doc = dict(
+    input_name="jd",
+    descr_short="Julian Date",
+    input_format="Julian Date (numeric)",
+    output_format="Julian Date (numeric)",
+    input_type="float, int, list, ndarray",
+    output_type="float, ndarray[float]",
+)
+
+
 class TimeSecs(TimeCxcSec):
     """
     Chandra X-ray Center seconds from 1998-01-01 00:00:00 TT.
@@ -252,6 +262,16 @@ class TimeSecs(TimeCxcSec):
     """
 
     name = "secs"
+
+    # Documentation inputs for convert functions
+    convert_doc = dict(
+        input_name="time",
+        descr_short="CXC seconds",
+        input_format="CXC seconds (numeric)",
+        output_format="CXC seconds (numeric)",
+        input_type="float, int, list, ndarray",
+        output_type="float, ndarray[float]",
+    )
 
 
 class TimeDate(TimeYearDayTime):
@@ -278,6 +298,20 @@ class TimeDate(TimeYearDayTime):
     """
 
     name = "date"
+
+    # Documentation inputs for convert functions
+    convert_doc = dict(
+        input_name="date",
+        descr_short="Date (Year, day-of-year, time)",
+        input_format="""
+    - YYYY:DDD:HH:MM:SS.sss
+    - YYYY:DDD:HH:MM:SS
+    - YYYY:DDD:HH:MM
+    - YYYY:DDD""",
+        output_format="YYYY:DDD:HH:MM:SS.sss",
+        input_type="str, bytes, float, list, ndarray",
+        output_type="str, ndarray[str]",
+    )
 
     def to_value(self, parent=None, **kwargs):
         if self.scale == "utc":
@@ -326,6 +360,16 @@ class TimeGreta(TimeDate):
     """
 
     name = "greta"
+
+    # Documentation inputs for convert functions
+    convert_doc = dict(
+        input_name="date",
+        descr_short="GRETA date",
+        input_format="YYYYDDD.HHMMSSsss (str or float)",
+        output_format="YYYYDDD.HHMMSSsss (str)",
+        input_type="str, bytes, float, list, np.ndarray",
+        output_type="str, np.ndarray[str]",
+    )
 
     subfmts = (
         ("date_hms", "%Y%j%H%M%S", "{year:d}{yday:03d}{hour:02d}{min:02d}{sec:02d}"),
@@ -383,7 +427,7 @@ class TimeGreta(TimeDate):
 
 class TimeMaude(TimeDate):
     """
-    Date as a 64-bit integer in format YYYYDDDhhmmsss, where sss is number of
+    Date as a 64-bit integer in format YYYYDDDHHMMSSsss, where sss is number of
     milliseconds.
 
     This can be input as an integer or string, but the output is always integer.
@@ -392,6 +436,14 @@ class TimeMaude(TimeDate):
     """
 
     name = "maude"
+    convert_doc = dict(
+        input_name="date",
+        descr_short="MAUDE date",
+        input_format="YYYYDDDHHMMSSsss (str or int)",
+        output_format="YYYYDDD.HHMMSSsss (int)",
+        input_type="str, bytes, int, list, ndarray",
+        output_type="int, ndarray[int]",
+    )
 
     subfmts = (
         ("date_hms", "%Y%j%H%M%S", "{year:d}{yday:03d}{hour:02d}{min:02d}{sec:02d}"),

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -11,12 +11,18 @@ import pytest
 from astropy.time import Time
 from Chandra.Time import DateTime
 
-from .. import CxoTime, convert_time_format, date2secs, secs2date
-
 # Test that cxotime.__init__ imports the CxoTime class and all converters like date2secs
 from cxotime import CxoTime, convert
 from cxotime import *  # noqa
 from cxotime.scripts import print_time_conversions
+from cxotime import CxoTime, convert_time_format
+from cxotime import secs2greta, secs2maude, secs2jd, secs2date  # noqa: F401
+from cxotime import greta2secs, greta2maude, greta2jd, greta2date  # noqa: F401
+from cxotime import maude2secs, maude2greta, maude2jd, maude2date  # noqa: F401
+from cxotime import jd2secs, jd2greta, jd2maude, jd2date  # noqa: F401
+from cxotime import date2secs, date2greta, date2maude, date2jd  # noqa: F401
+
+import cxotime.convert
 
 
 def test_cxotime_basic():
@@ -378,7 +384,7 @@ def test_convert_functions(fmt_val, val_type, fmt_out):
         assert np.all(exp == out)
 
     if (
-        fmt_in in convert.CONVERT_FORMATS
+        fmt_in in cxotime.convert.CONVERT_FORMATS
         and fmt_kind == val_kind
         and (val_kind == "U" or fmt_in == "secs")
     ):
@@ -392,8 +398,8 @@ def test_convert_functions(fmt_val, val_type, fmt_out):
     # Test the convenience functions like date2secs
     if (
         fmt_in != fmt_out
-        and fmt_in in convert.CONVERT_FORMATS
-        and fmt_out in convert.CONVERT_FORMATS
+        and fmt_in in cxotime.convert.CONVERT_FORMATS
+        and fmt_out in cxotime.convert.CONVERT_FORMATS
     ):
         func = globals()[f"{fmt_in}2{fmt_out}"]
         out3 = func(val)

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -11,18 +11,34 @@ import pytest
 from astropy.time import Time
 from Chandra.Time import DateTime
 
-# Test that cxotime.__init__ imports the CxoTime class and all converters like date2secs
-from cxotime import CxoTime, convert
-from cxotime import *  # noqa
-from cxotime.scripts import print_time_conversions
-from cxotime import CxoTime, convert_time_format
-from cxotime import secs2greta, secs2maude, secs2jd, secs2date  # noqa: F401
-from cxotime import greta2secs, greta2maude, greta2jd, greta2date  # noqa: F401
-from cxotime import maude2secs, maude2greta, maude2jd, maude2date  # noqa: F401
-from cxotime import jd2secs, jd2greta, jd2maude, jd2date  # noqa: F401
-from cxotime import date2secs, date2greta, date2maude, date2jd  # noqa: F401
-
 import cxotime.convert
+
+# Test that cxotime.__init__ imports the CxoTime class and all converters like date2secs
+from cxotime import (  # noqa: F401
+    CxoTime,
+    convert_time_format,
+    date2greta,
+    date2jd,
+    date2maude,
+    date2secs,
+    greta2date,
+    greta2jd,
+    greta2maude,
+    greta2secs,
+    jd2date,
+    jd2greta,
+    jd2maude,
+    jd2secs,
+    maude2date,
+    maude2greta,
+    maude2jd,
+    maude2secs,
+    secs2date,
+    secs2greta,
+    secs2jd,
+    secs2maude,
+)
+from cxotime.scripts import print_time_conversions
 
 
 def test_cxotime_basic():
@@ -93,7 +109,8 @@ def test_cxotime_from_datetime():
 
 
 def test_cxotime_vs_datetime():
-    # Note the bug (https://github.com/sot/Chandra.Time/issues/21), hence the odd first two lines
+    # Note the bug (https://github.com/sot/Chandra.Time/issues/21), hence the odd first
+    # two lines
     # >>> DateTime('2015:181:23:59:60.500').date
     # '2015:182:00:00:00.500'
     secs = DateTime(

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -11,6 +11,8 @@ import pytest
 from astropy.time import Time
 from Chandra.Time import DateTime
 
+from .. import CxoTime, convert_time_format, date2secs, secs2date
+
 # Test that cxotime.__init__ imports the CxoTime class and all converters like date2secs
 from cxotime import CxoTime, convert
 from cxotime import *  # noqa

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,12 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
+    'numpydoc',
 ]
+
+# Don't show summaries of the members in each class along with the
+# class' docstring
+numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -149,7 +154,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,3 +158,6 @@ API docs
 
 .. automodule:: cxotime.cxotime
    :members:
+
+.. automodule:: cxotime.convert
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,28 +32,6 @@ greta     YYYYDDD.hhmmsssss (string)                   utc
 maude     YYYYDDDhhmmsssss (integer)                   utc
 ========= ===========================================  =======
 
-
-Compatibility with DateTime
----------------------------
-
-The key differences between |CxoTime| and DateTime_ are:
-
-- In |CxoTime| the date '2000:001' is '2000:001:00:00:00' instead of
-  '2000:001:12:00:00' in DateTime_ (prior to version 4.0).  In most cases this
-  interpretation is more rational and expected.
-
-- In |CxoTime| the date '2001-01-01T00:00:00' is UTC by default, while in
-  DateTime_ that is interpreted as TT by default.  This is triggered by
-  the ``T`` in the middle.  A date like '2001-01-01 00:00:00' defaults
-  to UTC in both |CxoTime| and DateTime_.
-
-- In |CxoTime| the difference of two dates is a TimeDelta_ object
-  which is transformable to any time units.  In DateTime_ the difference
-  of two dates is a floating point value in days.
-
-- Conversely, starting with |CxoTime| one can add or subtract a TimeDelta_ or
-  any quantity with time units.
-
 The standard built-in Time formats that are available in |CxoTime| are:
 
 ===========  ==============================
@@ -78,11 +56,8 @@ yday         2000:001:00:00:00.000
 ===========  ==============================
 
 
-Examples
---------
-
 Basic initialization
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 ::
 
   >>> from cxotime import CxoTime
@@ -109,7 +84,7 @@ Basic initialization
   'date'
 
 Guessing and specifying the format
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------
 
 Generally speaking ``CxoTime`` will successfully guess the format for
 string-based times. However this requires some time, so if you know the
@@ -125,39 +100,141 @@ argument.
    :maxdepth: 2
 
 
-Fast conversion between Date and CXC seconds
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Fast conversion between formats
+-------------------------------
 
-For fast conversion of an input date or dates in Year Day-of-Year date format,
-the function :func:`~cxotime.cxotime.date2secs` can be used.
+Converting between time formats (e.g. from CXC seconds to Year Day-of-Year) is
+easily done with the |CxoTime| class, but this involves some overhead and is
+relatively slow for scalar values or small arrays (less than around 100
+elements). For applications where this conversion time ends up being significant,
+the `cxotime` package provides a different interface that is typically at least
+10x faster for scalar values or small arrays.
 
-This is a specialized function similar to the legacy ``Chandra.Time.date2secs``
-that allows for fast conversion of a single date or an array of dates to CXC
-seconds.  It is intended to be used ONLY when the input date is known to be in
-the correct Year Day-of-Year format.
+For fast conversion of an input date or dates to a different format there are
+two options that are described in the next two sections.
 
-The main use case is for a single date or a few dates. For a single date this
-function is about 10 times faster than the equivalent call to
-``CxoTime(date).secs``. For a large array of dates (more than about 100) this
-function  is not significantly faster.
+``convert_time_format``
+^^^^^^^^^^^^^^^^^^^^^^^
 
-This function will raise an exception if the input date is not in one of
-these allowed formats:
+The first option is a generalized time format conversion function
+:func:`~cxotime.convert.convert_time_format` that can be used to convert between
+any of the supported *fast* formats:
 
-- YYYY:DDD
-- YYYY:DDD:HH:MM
-- YYYY:DDD:HH:MM:SS
-- YYYY:DDD:HH:MM:SS.sss
+- `secs`: CXC seconds
+- `date`: Year Day-of-Year
+- `greta`: GRETA format (input can be string, float or int)
+- `maude`: MAUDE format (input can be string or int)
+- `jd`: Julian Day (requires `fmt_in="jd"` to identity this format)
 
-Conversely, for fast conversion from CXC seconds to Year Day-of-Year date, the
-function :func:`~cxotime.cxotime.secs2date` can be used. For scalar inputs this
-is 15-20 times faster than the equivalent call to ``CxoTime(secs).date``.
+For example::
+
+  >>> from cxotime import convert_time_format
+  >>> convert_time_format("2022:001:00:00:00.123", "greta")
+  '2022001.000000123'
+  >>> convert_time_format(100.123, "date")
+ '1998:001:00:00:36.939'
+  >>> convert_time_format(2459580.5, "date", fmt_in="jd")
+  '2022:001:00:00:00.000'
+
+Note that this function can be used to convert between any of the supported |CxoTime|
+formats, but it will internally use a |CxoTime| object so the performance will not be
+improved. For example::
+
+    >>> convert_time_format(2022.123, fmt_out="date", fmt_in="frac_year")
+    '2022:045:21:28:48.000'
+
+    # Exactly equivalent to:
+    >>> CxoTime(2022.123, format="frac_year").date
+    '2022:045:21:28:48.000'
+
+Convenience functions like ``secs2date``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For historical compatibility and for succinct code, direct conversion between any two
+of the "fast" formats is also available via convenience functions. These have the name
+``<fmt_in>2<fmt_out>`` where ``fmt_in`` and ``fmt_out`` are the input and output formats.
+Examples include :func:`~cxotime.convert.date2secs`, :func:`~cxotime.convert.secs2greta`,
+and :func:`~cxotime.convert.greta2jd`.
+
+::
+    >>> from cxotime import secs2greta
+    >>> secs2greta([100, 1000])
+    array(['1998001.000036816', '1998001.001536816'], dtype='<U17')
+
+
+Print common time conversions
+-----------------------------
+
+The `cxotime` package has functionality to convert a time betweeen a variety of common
+time formats. This convenience function is available in two ways, either as a
+command line script or as class method :meth:`~cxotime.CxoTime.print_conversions`::
+
+    $ cxotime 2022:002:12:00:00
+    local       2022 Sun Jan 02 07:00:00 AM EST
+    iso_local   2022-01-02T07:00:00-05:00
+    date        2022:002:12:00:00.000
+    cxcsec      757512069.184
+    decimalyear 2022.00411
+    iso         2022-01-02 12:00:00.000
+    unix        1641124800.000
+
+::
+
+    $ cxotime  # Print current time
+    local       2023 Tue Jan 10 01:41:02 PM EST
+    iso_local   2023-01-10T13:41:02.603000-05:00
+    date        2023:010:18:41:02.603
+    cxcsec      789763331.787
+    decimalyear 2023.02679
+    iso         2023-01-10 18:41:02.603
+    unix        1673376062.603
+
+::
+
+    $ python
+    >>> from cxotime import CxoTime
+    >>> tm = CxoTime("2022-01-02 12:00:00.000")
+    >>> tm.print_conversions()
+    local       2022 Sun Jan 02 07:00:00 AM EST
+    iso_local   2022-01-02T07:00:00-05:00
+    date        2022:002:12:00:00.000
+    cxcsec      757512069.184
+    decimalyear 2022.00411
+    iso         2022-01-02 12:00:00.000
+    unix        1641124800.000
+
+Compatibility with DateTime
+---------------------------
+
+The key differences between |CxoTime| and DateTime_ are:
+
+- In |CxoTime| the date '2000:001' is '2000:001:00:00:00' instead of
+  '2000:001:12:00:00' in DateTime_ (prior to version 4.0).  In most cases this
+  interpretation is more rational and expected.
+
+- In |CxoTime| the date '2001-01-01T00:00:00' is UTC by default, while in
+  DateTime_ that is interpreted as TT by default.  This is triggered by
+  the ``T`` in the middle.  A date like '2001-01-01 00:00:00' defaults
+  to UTC in both |CxoTime| and DateTime_.
+
+- In |CxoTime| the difference of two dates is a TimeDelta_ object
+  which is transformable to any time units.  In DateTime_ the difference
+  of two dates is a floating point value in days.
+
+- Conversely, starting with |CxoTime| one can add or subtract a TimeDelta_ or
+  any quantity with time units.
 
 API docs
 --------
 
+Cxotime
+^^^^^^^
+
 .. automodule:: cxotime.cxotime
    :members:
+
+Converters
+^^^^^^^^^^
 
 .. automodule:: cxotime.convert
    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,13 +128,13 @@ any of the supported *fast* formats:
 
 For example::
 
-  >>> from cxotime import convert_time_format
-  >>> convert_time_format("2022:001:00:00:00.123", "greta")
-  '2022001.000000123'
-  >>> convert_time_format(100.123, "date")
- '1998:001:00:00:36.939'
-  >>> convert_time_format(2459580.5, "date", fmt_in="jd")
-  '2022:001:00:00:00.000'
+    >>> from cxotime import convert_time_format
+    >>> convert_time_format("2022:001:00:00:00.123", "greta")
+    '2022001.000000123'
+    >>> convert_time_format(100.123, "date")
+    '1998:001:00:00:36.939'
+    >>> convert_time_format(2459580.5, "date", fmt_in="jd")
+    '2022:001:00:00:00.000'
 
 Note that this function can be used to convert between any of the supported |CxoTime|
 formats, but it will internally use a |CxoTime| object so the performance will not be
@@ -189,9 +189,8 @@ command line script or as class method :meth:`~cxotime.CxoTime.print_conversions
     iso         2023-01-10 18:41:02.603
     unix        1673376062.603
 
-::
+or in python::
 
-    $ python
     >>> from cxotime import CxoTime
     >>> tm = CxoTime("2022-01-02 12:00:00.000")
     >>> tm.print_conversions()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,10 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+
+[tool.flake8]
+exclude = '''
+/(
+    docs
+)/
+'''


### PR DESCRIPTION
## Description

Creating a `CxoTime` object is unfortunately slow, taking a few hundred microsecs. Often the only reason for this it so convert to a different format like `date` or `secs`. This PR includes functionality to do those conversions in tens of microsecs (for the scalar case).

Features:
* Includes a functional interface `convert_time_format` that converts between `date`, `secs`, `jd`, `maude` and `greta` formats without creating a `CxoTime` object. It can also infer the input time format in a performant way for common formats (in particular `date` and `secs`).
* Generalize the convenience methods `date2secs` and `secs2date` fast converters to include all combinations of the supported fast formats in `convert_time_format`.
* Update the `CxoTime` initializers so that `CxoTime(tm)` returns the `tm` object if it is already a `CxoTime` instance. This allows writing code like `start = CxoTime(start)` with no performance penalty if `start` is already a `CxoTime`.  `CxoTime(tm, copy=True)` will make a copy as expected.'

This is based on the `remove-cxotime-fast-parser` branch since that was needed. The intent is to rebase on master once #34  is merged.

### Todo
- [x] Docs
- [x] Add unit tests
- [x] Ensure reasonable docstrings for the convenience conversion functions
- [x] Some code clean-up

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
The `date2secs` and `secs2date` functions were removed from the `cxotime.cxotime` so `from cxotime.cxotime import date2secs` will now fail. This was not the public interface and code should be using `from cxotime import date2secs`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by Jean
- [x] Linux (in a dev ska3-matlab-2023.4rc6 env)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Roughly speaking using `CxoTime` for a single value is around 350 µs, while the "fast" functions will take around 25 µs.
```
>>> from cxotime import *
>>> %timeit CxoTime(100.0).greta
373 µs ± 6.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> %timeit secs2greta(100.0)
24.4 µs ± 577 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> %timeit convert_time_format(100.0, 'greta')
28.1 µs ± 1.71 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> %timeit convert_time_format(100.0, 'greta', fmt_in='secs')
24.2 µs ± 457 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> %timeit greta2secs(2020001.123456789)
25.4 µs ± 1.85 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> %timeit greta2secs('2020001.123456789')
20.7 µs ± 1.61 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
Ultimate conversion speed is about 0.2 µs / conversion for large arrays:
```
>>> x = ["2020001.123456789"] * 1000
>>> %timeit greta2secs(x)
358 µs ± 5.43 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> x = np.array(["2020001.123456789"] * 1000)
>>> %timeit greta2secs(x)
218 µs ± 4.21 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
