### PR TITLE
Improve time conversion helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
-      - id: isort
-        name: isort (python)
-        language_version: python3.10
+    - id: isort
+      name: isort (python)
+      language_version: python3.10

--- a/cxotime/scripts/print_time_conversions.py
+++ b/cxotime/scripts/print_time_conversions.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
+
+from cxotime import CxoTime
+
+
+def main(date=None, file=sys.stdout):
+    """Interface to entry_point script ``cxotime`` to print time conversions.
+
+    :param date: str, float, optional
+        Date for time conversion if sys.argv[1] is not provided. Mostly for testing.
+    :param file: file-like, optional
+        File-like object to write output (default=sys.stdout). Mostly for testing.
+    """
+    if date is None:
+        if len(sys.argv) > 2:
+            print("Usage: cxotime [date]")
+            sys.exit(1)
+
+        if len(sys.argv) == 2:
+            date = sys.argv[1]
+
+    # If the input can be converted to a float then it is a CXC seconds value
+    try:
+        date = float(date)
+    except Exception:
+        pass
+
+    date = CxoTime(date)
+    date.print_conversions(file)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 entry_points = {
     "console_scripts": [
-        "cxotime = cxotime.cxotime:print_time_conversions",
+        "cxotime = cxotime.scripts.print_time_conversions:main",
     ]
 }
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     use_scm_version=True,
     setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     zip_safe=False,
-    packages=["cxotime", "cxotime.tests"],
+    packages=["cxotime", "cxotime.scripts", "cxotime.tests"],
     tests_require=["pytest"],
     cmdclass=cmdclass,
     entry_points=entry_points,


### PR DESCRIPTION
## Description

This improves the time conversion helper utilities which are available as a CLI via the `cxotime` script or the `print_conversions()` method of `CxoTime`. 

- Factor out the conversions bit into a new `get_conversions()` method. 
- Add parameters to methods that allow for unit testing.
- CLI script was put into a more standard place in `scripts`, now being run through `main()`.
- Conversion to local time is now done using timezone support in a built-in module available in Python 3.10.
  - Unlike the previous method, this gives the expected local time zone even after `django.setup()` is run if the `TZ` environment var is removed.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new unit tests)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
```
In [1]: import kadi.events

In [2]: kadi.events.eclipses
Out[2]: <EventQuery: Eclipse>

In [3]: import os

In [4]: os.environ["TZ"]
Out[4]: 'America/Chicago'

In [5]: del os.environ["TZ"]

In [6]: from cxotime import CxoTime

In [7]: CxoTime("2022:300:01:00:00.000").get_conversions()
Out[7]: 
{'local': '2022 Wed Oct 26 09:00:00 PM EDT',
 'iso_local': '2022-10-26T21:00:00-04:00',
 'date': '2022:300:01:00:00.000',
 'cxcsec': 783219669.184,
 'decimalyear': 2022.8192922374428,
 'iso': '2022-10-27 01:00:00.000',
 'unix': 1666832400.0}
```
In [8]: os.environ["TZ"] = "America/Chicago"

In [9]: CxoTime("2022:300:01:00:00.000").get_conversions()
Out[9]: 
{'local': '2022 Wed Oct 26 08:00:00 PM CDT',
 'iso_local': '2022-10-26T20:00:00-05:00',
 'date': '2022:300:01:00:00.000',
 'cxcsec': 783219669.184,
 'decimalyear': 2022.8192922374428,
 'iso': '2022-10-27 01:00:00.000',
 'unix': 1666832400.0}

