### PR TITLE
Fix test on Windows

### DIFF
--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -290,7 +290,16 @@ def test_get_conversions():
         "iso": "2010-01-01 00:00:00.000",
         "unix": 1262304000.0,
     }
-    assert out == exp
+    exp2 = {
+        "local": "2009 Thu Dec 31 07:00:00 PM Eastern Standard Time",
+        "iso_local": "2009-12-31T19:00:00-05:00",
+        "date": "2010:001:00:00:00.000",
+        "cxcsec": 378691266.184,
+        "decimalyear": 2010.0,
+        "iso": "2010-01-01 00:00:00.000",
+        "unix": 1262304000.0,
+    }
+    assert out == exp or out == exp2
 
 
 @pytest.mark.parametrize(
@@ -307,7 +316,15 @@ cxcsec      378691266.184
 decimalyear 2010.00000
 iso         2010-01-01 00:00:00.000
 unix        1262304000.000"""
+    exp2 = """\
+local       2009 Thu Dec 31 07:00:00 PM Eastern Standard Time
+iso_local   2009-12-31T19:00:00-05:00
+date        2010:001:00:00:00.000
+cxcsec      378691266.184
+decimalyear 2010.00000
+iso         2010-01-01 00:00:00.000
+unix        1262304000.000"""
     out_str = out.getvalue()
     # Strip all trailing whitespace on each line
     out_str = "\n".join([line.rstrip() for line in out_str.splitlines()])
-    assert out_str == exp
+    assert out_str == exp or out_str == exp2


### PR DESCRIPTION
## Description

Apparently, the `local` time format is different on Windows. `CxoTime('2023:001').get_conversions()["local"]` gives the following on Windows:
```
'2022 Sat Dec 31 07:00:00 PM Eastern Standard Time'
```
and this on Linux/OS-X:
```
'2022 Sat Dec 31 07:00:00 PM EST'
```

This causes some test errors.

I am not convinced this is the right fix, but this prevents the failure.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [x] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
