### PR TITLE
Short circuit convert_time_format for a CxoTime object

### DIFF
--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -36,6 +36,11 @@ def convert_time_format(val, fmt_out, *, fmt_in=None):
     val_out : str
         Time string in output format
     """
+    # If this is already a CxoTime object then return the attribute without all the
+    # conversion machinery.
+    if isinstance(val, CxoTime):
+        return getattr(val, fmt_out)
+
     jd1, jd2 = None, None
     if fmt_in is None:
         # Get the format. For some formats the jd1/jd2 values are generated as a

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -447,3 +447,9 @@ def test_convert_functions(fmt_val, val_type, fmt_out):
         out3 = func(val)
         assert type(out) is type(out3)
         assert np.all(out == out3)
+
+
+def test_convert_time_format_obj():
+    """Explicit test of convert_time_format for CxoTime object"""
+    tm = CxoTime(100.0)
+    assert tm.date == convert_time_format(tm, "date")


### PR DESCRIPTION
## Description

This is a minor change to improve performance for a corner case when `convert_time_format` is called with a `CxoTime` object. In that case the fastest path is to use the object attribute.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
