### PR TITLE
Fix a precision issue in convert_time_format

### DIFF
--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -4,6 +4,7 @@ import sys
 
 import erfa
 import numpy as np
+from astropy.time.core import day_frac
 from astropy.time.formats import TIME_FORMATS, TimeYearDayTime, _parse_times
 
 from .cxotime import CxoTime, TimeGreta, TimeMaude
@@ -264,12 +265,14 @@ def convert_jd1_jd2_to_date(jd1, jd2):
 
 
 def convert_secs_to_jd1_jd2(secs):
-    jd2 = 0.0
-    try:
-        jd1 = secs / 86400.0 + 2450814.5
-    except TypeError:
-        # For a list input
-        jd1 = np.array(secs, dtype=np.float64) / 86400.0 + 2450814.5
+    if not isinstance(secs, (float, np.ndarray)):
+        secs = np.asarray(secs, dtype=float)
+
+    day, frac = day_frac(secs, 0.0, divisor=86400.0)
+
+    # CxoTime("1998:001:00:00:00.000").jd1,2
+    jd1 = 2450814.0 + day
+    jd2 = 0.5 + frac
 
     # In these ERFA calls ignore the return value since we know jd1, jd2 are OK.
     # Checking the return value via np.any is quite slow.

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -416,14 +416,10 @@ def test_convert_functions(fmt_val, val_type, fmt_out):
     exp = getattr(CxoTime(val, format=fmt_in), fmt_out)
     out = convert_time_format(val, fmt_out, fmt_in=fmt_in)
 
-    exp_kind = np.asarray(exp).dtype.kind
     val_kind = np.asarray(val).dtype.kind
 
     assert type(exp) is type(out)
-    if exp_kind == "f":
-        assert np.allclose(exp, out, rtol=1e-12)
-    else:
-        assert np.all(exp == out)
+    assert np.all(exp == out)
 
     if (
         fmt_in in cxotime.convert.CONVERT_FORMATS


### PR DESCRIPTION
## Description

This fixes a precision issue in `convert_time_format` when converting from `secs` to other formats. The earlier version was using 64-bit float arithmetic which could lead to errors of order 2e-5 sec. 

This makes no practical difference for Chandra analysis but did lead to regression test failures when a computed time series ended up having differences when expressed as a date. Basically one time series element would go just over the bin boundary for the millisecond date precision.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-perf) ➜  cxotime git:(fix-precision-convert-secs-to-jd) git rev-parse HEAD
f5208d15cd54d354957a532e1c5fa7d9bc003d06
(ska3-perf) ➜  cxotime git:(fix-precision-convert-secs-to-jd) pytest cxotime
==================================================== test session starts ====================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 229 items                                                                                                         

cxotime/tests/test_cxotime.py ....................................................................................... [ 37%]
..................................................................................................................... [ 89%]
.........................                                                                                             [100%]

==================================================== 229 passed in 1.10s ====================================================
```

Independent check of unit tests by Jean
- [x] Linux 

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This fixes kadi regression test failures noted in https://chandramission.slack.com/archives/G01LN40AXPG/p1700238555750149?thread_ts=1699976188.068579&cid=G01LN40AXPG.
