### PR TITLE
Add CxoTimeDescr descriptor and CxoTime.NOW sentinel

### DIFF
--- a/cxotime/__init__.py
+++ b/cxotime/__init__.py
@@ -3,8 +3,8 @@ import ska_helpers
 from astropy import units
 from astropy.time import TimeDelta
 
-from .convert import *
-from .cxotime import CxoTime, CxoTimeLike
+from .convert import *  # noqa: F401, F403
+from .cxotime import *  # noqa: F401, F403
 
 __version__ = ska_helpers.get_version(__package__)
 

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -515,8 +515,10 @@ class CxoTimeDescriptor(TypedDescriptor):
     This allows setting the attribute with any ``CxoTimeLike`` value.
 
     Note that setting this descriptor to ``None`` will set the attribute to ``None``,
-    which is different than ``CxoTime(None)`` which returns the current time. To set
-    an attribute to the current time, set it with ``CxoTime.now()``.
+    which is different than ``CxoTime(None)`` which returns the current time.
+
+    To set an attribute to the current time, use ``CxoTime.NOW``, either as the default
+    or when setting the attribute.
 
     Parameters
     ----------
@@ -524,8 +526,8 @@ class CxoTimeDescriptor(TypedDescriptor):
         Default value for the attribute which is provide to the ``CxoTime`` constructor.
         If not specified or ``None``, the default for the attribute is ``None``.
     required : bool, optional
-        If ``True``, the attribute is required to be set explicitly when the object
-        is created. If ``False`` the default value is used if the attribute is not set.
+        If ``True``, the attribute is required to be set explicitly when the object is
+        created. If ``False`` the default value is used if the attribute is not set.
 
     Examples
     --------
@@ -534,13 +536,13 @@ class CxoTimeDescriptor(TypedDescriptor):
     >>> @dataclass
     ... class MyClass:
     ...     start: CxoTime | None = CxoTimeDescriptor()
-    ...     stop: CxoTime | None = CxoTimeDescriptor()
+    ...     stop: CxoTime = CxoTimeDescriptor(default=CxoTime.NOW)
     ...
-    >>> obj = MyClass("2023:100")
+    >>> obj = MyClass("2023:100")  # Example run at 2024:006:12:02:35
     >>> obj.start
     <CxoTime object: scale='utc' format='date' value=2023:100:00:00:00.000>
-    >>> obj.stop is None
-    True
+    >>> obj.stop
+    <CxoTime object: scale='utc' format='date' value=2024:006:12:02:35.000>
     """
 
     cls = CxoTime

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -9,6 +9,10 @@ import numpy as np
 import numpy.typing as npt
 from astropy.time import Time, TimeCxcSec, TimeDecimalYear, TimeJD, TimeYearDayTime
 from astropy.utils import iers
+from ska_helpers.utils import TypedDescriptor
+
+__all__ = ["CxoTime", "CxoTimeLike", "CxoTimeDescriptor"]
+
 
 # TODO: use npt.NDArray with numpy 1.21
 CxoTimeLike = Union["CxoTime", str, float, int, np.ndarray, npt.ArrayLike, None]
@@ -498,3 +502,40 @@ class TimeMaude(TimeDate):
         return out
 
     value = property(to_value)
+
+
+class CxoTimeDescriptor(TypedDescriptor):
+    """Descriptor for an attribute that is CxoTime (in date format) or None if not set.
+
+    This allows setting the attribute with any ``CxoTimeLike`` value.
+
+    Note that setting this descriptor to ``None`` will set the attribute to ``None``,
+    which is different than ``CxoTime(None)`` which returns the current time. To set
+    an attribute to the current time, set it with ``CxoTime.now()``.
+
+    Parameters
+    ----------
+    default : CxoTimeLike, optional
+        Default value for the attribute which is provide to the ``CxoTime`` constructor.
+        If not specified or ``None``, the default for the attribute is ``None``.
+    required : bool, optional
+        If ``True``, the attribute is required to be set explicitly when the object
+        is created. If ``False`` the default value is used if the attribute is not set.
+
+    Examples
+    --------
+    >>> from dataclasses import dataclass
+    >>> from cxotime import CxoTime, CxoTimeDescriptor
+    >>> @dataclass
+    ... class MyClass:
+    ...     start: CxoTime | None = CxoTimeDescriptor()
+    ...     stop: CxoTime | None = CxoTimeDescriptor()
+    ...
+    >>> obj = MyClass("2023:100")
+    >>> obj.start
+    <CxoTime object: scale='utc' format='date' value=2023:100:00:00:00.000>
+    >>> obj.stop is None
+    True
+    """
+
+    cls = CxoTime

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -84,13 +84,18 @@ class CxoTime(Time):
 
     """
 
+    # Sentinel object for CxoTime(CxoTime.NOW) to return the current time. See e.g.
+    # https://python-patterns.guide/python/sentinel-object/.
+    NOW = object()
+
     def __new__(cls, *args, **kwargs):
-        # Handle the case of `CxoTime()` which returns the current time. This is
-        # for compatibility with DateTime.
-        if not args or (len(args) == 1 and args[0] is None):
+        # Handle the case of `CxoTime()`, `CxoTime(None)`, or `CxoTime(CxoTime.NOW)`,
+        # all of which return the current time. This is for compatibility with DateTime.
+        if not args or (len(args) == 1 and (args[0] is None or args[0] is CxoTime.NOW)):
             if not kwargs:
                 # Stub in a value for `val` so super()__new__ can run since `val`
-                # is a required positional arg.
+                # is a required positional arg. NOTE that this change to args here does
+                # not affect the args in the call to __init__() below.
                 args = (None,)
             else:
                 raise ValueError("cannot supply keyword arguments with no time value")
@@ -108,7 +113,7 @@ class CxoTime(Time):
             # implies copy=False) then no other initialization is needed.
             return
 
-        if len(args) == 1 and args[0] is None:
+        if len(args) == 1 and (args[0] is None or args[0] is CxoTime.NOW):
             # Compatibility with DateTime and allows kwarg default of None with
             # input casting like `date = CxoTime(date)`.
             args = ()

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -493,7 +493,7 @@ def test_cxotime_descriptor_is_required():
 
     with pytest.raises(
         ValueError,
-        match="cannot set required attribute 'time' to None",
+        match="attribute 'time' is required and cannot be set to None",
     ):
         MyClass()
 

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -530,10 +530,15 @@ def test_cxotime_descriptor_with_NOW():
     obj1 = MyData()
     assert (CxoTime.now() - obj1.stop).sec < 0.1
 
-    # Wait for a second and make a new object and check that the stop time is 1 second
-    # later. This proves the NOW sentinel is evaluated at object creation time not class
-    # definition time.
-    time.sleep(1.0)
+    # Wait for 0.5 second and make a new object and check that the stop time is 0.5
+    # second later. This proves the NOW sentinel is evaluated at object creation time
+    # not class definition time.
+    time.sleep(0.5)
     obj2 = MyData()
+    dt = obj2.stop - obj1.stop
+    assert round(dt.sec, 1) == 0.5
+
+    time.sleep(0.5)
+    obj2.stop = CxoTime.NOW
     dt = obj2.stop - obj1.stop
     assert round(dt.sec, 1) == 1.0

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -5,6 +5,7 @@ tested, so this simply confirms that the add-on in CxoTime works.
 """
 import io
 import time
+from dataclasses import dataclass
 
 import astropy.units as u
 import numpy as np
@@ -17,6 +18,7 @@ import cxotime.convert
 # Test that cxotime.__init__ imports the CxoTime class and all converters like date2secs
 from cxotime import (  # noqa: F401
     CxoTime,
+    CxoTimeDescriptor,
     convert_time_format,
     date2greta,
     date2jd,
@@ -454,3 +456,65 @@ def test_convert_time_format_obj():
     """Explicit test of convert_time_format for CxoTime object"""
     tm = CxoTime(100.0)
     assert tm.date == convert_time_format(tm, "date")
+
+
+def test_cxotime_descriptor_not_required_no_default():
+    @dataclass
+    class MyClass:
+        time: CxoTime | None = CxoTimeDescriptor()
+
+    obj = MyClass()
+    assert obj.time is None
+
+    obj = MyClass(time="2020:001")
+    assert isinstance(obj.time, CxoTime)
+    assert obj.time.value == "2020:001:00:00:00.000"
+    assert obj.time.format == "date"
+
+    tm = CxoTime(100.0)
+    assert tm.format == "secs"
+
+    # Initialize with CxoTime object
+    obj = MyClass(time=tm)
+    assert isinstance(obj.time, CxoTime)
+    assert obj.time.value == 100.0
+
+    # CxoTime does not copy an existing CxoTime object for speed
+    assert obj.time is tm
+
+
+def test_cxotime_descriptor_is_required():
+    @dataclass
+    class MyClass:
+        time: CxoTime = CxoTimeDescriptor(required=True)
+
+    obj = MyClass(time="2020-01-01")
+    assert obj.time.date == "2020:001:00:00:00.000"
+
+    with pytest.raises(
+        ValueError,
+        match="cannot set required attribute 'time' to None",
+    ):
+        MyClass()
+
+
+def test_cxotime_descriptor_has_default():
+    @dataclass
+    class MyClass:
+        time: CxoTime = CxoTimeDescriptor(default="2020-01-01")
+
+    obj = MyClass()
+    assert obj.time.value == "2020-01-01 00:00:00.000"
+
+    obj = MyClass(time="2023:100")
+    assert obj.time.value == "2023:100:00:00:00.000"
+
+
+def test_cxotime_descriptor_is_required_has_default_exception():
+    with pytest.raises(
+        ValueError, match="cannot set both 'required' and 'default' arguments"
+    ):
+
+        @dataclass
+        class MyClass1:
+            time: CxoTime = CxoTimeDescriptor(default=100.0, required=True)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -202,6 +202,48 @@ or in python::
     iso         2022-01-02 12:00:00.000
     unix        1641124800.000
 
+CxoTime.NOW sentinel
+--------------------
+
+The |CxoTime| class has a special sentinel value ``CxoTime.NOW`` which can be used
+to specify the current time.  This is useful for example when defining a function that
+has accepts a CxoTime-like argument that defaults to the current time.
+
+.. note:: Prior to introduction of ``CxoTime.NOW``, the standard idiom was to specify
+    ``None`` as the argument default to indicate the current time.  This is still
+    supported but is strongly discouraged for new code.
+
+For example::
+
+    >>> from cxotime import CxoTime
+    >>> def my_func(stop=CxoTime.NOW):
+    ...     stop = CxoTime(stop)
+    ...     print(stop)
+    ...
+    >>> my_func()
+    2024:006:11:37:41.930
+
+This can also be used in a `dataclass
+<https://docs.python.org/3/library/dataclasses.html>`_ to specify an attribute that is
+optional and defaults to the current time when the object is created::
+
+    >>> import time
+    >>> from dataclasses import dataclass
+    >>> from cxotime import CxoTime, CxoTimeDescriptor
+    >>> @dataclass
+    ... class MyData:
+    ...     start: CxoTime = CxoTimeDescriptor(required=True)
+    ...     stop: CxoTime = CxoTimeDescriptor(default=CxoTime.NOW)
+    ...
+    >>> obj1 = MyData("2022:001")
+    >>> print(obj1.start)
+    2022:001:00:00:00.000
+    >>> time.sleep(2)
+    >>> obj2 = MyData("2022:001")
+    >>> dt = obj2.stop - obj1.stop
+    >>> round(dt.sec, 2)
+    2.0
+
 Compatibility with DateTime
 ---------------------------
 


### PR DESCRIPTION
## Description

This adds a descriptor that allows for `dataclass` attributes that are cast as `CxoTime`. This is most obvious looking at the test or docs.

This also adds a new class attribute `CxoTime.NOW` which is the new preferred way to specify the current time. Functions that used to be like 
```
def func(stop=None):
    stop = CxoTime(stop)
    ...
```
should now be:
```
def func(stop=CxoTime.NOW):
    stop = CxoTime(stop)
    ...
```

While in the package I gave the `cxotime.py` module an `__all__` attribute.

## Requires

- https://github.com/sot/ska_helpers/pull/53
- https://github.com/sot/ska_helpers/pull/54

## Interface impacts

<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (new tests)
```
(masters) ➜  cxotime git:(cxotime-descr) git rev-parse HEAD                                                             
f0f3d24d17f318c54b483e644ead80142b7439e1
(masters) ➜  cxotime git:(cxotime-descr) pytest
===================================================== test session starts ======================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 235 items                                                                                                            

cxotime/tests/test_cxotime.py .......................................................................................... [ 38%]
........................................................................................................................ [ 89%]
.........................                                                                                                [100%]

===================================================== 235 passed in 2.15s ======================================================
```

Independent check of unit tests by Jean
- [x] Linux
- [x] Mac (output below)

```
(ska3) flame:cxotime jean$ git rev-parse HEAD
f0f3d24d17f318c54b483e644ead80142b7439e1
(ska3) flame:cxotime jean$ python -c "import ska_helpers; print(ska_helpers.__version__);"
0.13.1.dev8+gd7f2e18
(ska3) flame:cxotime jean$ pytest
=================================================================================== test session starts ===================================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jean/git/cxotime
plugins: timeout-2.1.0, anyio-3.6.2
collected 235 items                                                                                                                                                                       

cxotime/tests/test_cxotime.py ..................................................................................................................................................... [ 63%]
......................................................................................                                                                                              [100%]

=================================================================================== 235 passed in 2.50s ===================================================================================
(ska3) flame:cxotime jean$ 
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
