### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -278,7 +278,7 @@ class CxoTime(Time):
         out["value"].info.format = "<s"
 
         # Remove the header and print
-        lines = out.pformat_all()[2:]
+        lines = out.pformat()[2:]
         print("\n".join(lines), file=file)
 
     def get_conversions(self):


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Requirements

Astropy >= 7.0.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc5) ~/SAO/git/cxotime pformat $ pytest cxotime
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 250 items                                                                                                                           

cxotime/tests/test_cxotime.py ......................................................................................................... [ 42%]
..................................................................................................................................      [ 94%]
cxotime/tests/test_cxotime_linspace.py ...............                                                                                  [100%]

============================================================= 250 passed in 1.57s =============================================================
(ska3-flight-2025.0rc5) ~/SAO/git/cxotime pformat $ git rev-parse --short HEAD                            
d55fa2e
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
