### PR TITLE
Fix mistake converting string date during leap second to jd1, jd2

### DIFF
--- a/cxotime/convert.py
+++ b/cxotime/convert.py
@@ -241,7 +241,7 @@ def convert_string_to_jd1_jd2(date, time_format_cls):
 
 
 def convert_jd1_jd2_to_date(jd1, jd2):
-    iys, ims, ids, ihmsfs = erfa.d2dtf(b"TT", 3, jd1, jd2)
+    iys, ims, ids, ihmsfs = erfa.d2dtf(b"UTC", 3, jd1, jd2)
     ihrs = ihmsfs["h"]
     imins = ihmsfs["m"]
     isecs = ihmsfs["s"]

--- a/cxotime/tests/test_cxotime.py
+++ b/cxotime/tests/test_cxotime.py
@@ -405,7 +405,7 @@ inputs = [
     ("iso", "2001-01-01 02:03:04.123", "U"),
 ]
 
-test_fmts = {fmt_name for fmt_name, val, fmt_kind in inputs}
+test_fmts = {fmt_name for fmt_name, _, _ in inputs}
 
 
 @pytest.mark.parametrize("fmt_val", inputs)
@@ -452,6 +452,26 @@ def test_convert_functions(fmt_val, val_type, fmt_out):
         out3 = func(val)
         assert type(out) is type(out3)
         assert np.all(out == out3)
+
+
+tm_leapsec = CxoTime("2016-12-31T23:59:60.5")
+inputs_leapsec = [
+    (fmt, val := getattr(tm_leapsec, fmt), np.array(val).dtype.kind)
+    for fmt in test_fmts
+]
+
+
+@pytest.mark.parametrize("fmt_val", inputs_leapsec)
+@pytest.mark.parametrize("fmt_out", test_fmts)
+def test_convert_functions_leapsec(fmt_val, fmt_out):
+    """Test fast convert for a time within a leap second"""
+    fmt_in, val, _ = fmt_val
+
+    exp = getattr(CxoTime(val, format=fmt_in), fmt_out)
+    out = convert_time_format(val, fmt_out, fmt_in=fmt_in)
+
+    assert type(exp) is type(out)
+    assert np.all(exp == out)
 
 
 def test_convert_time_format_obj():


### PR DESCRIPTION
## Description

The function `convert_string_to_jd1_jd2` mistakenly used the `TT` scale for conversion. I do not understand where that came from, but `UTC` is the right answer because all the Chandra string-based date formats with fast converter support are UTC.

This only impacts conversions for times within a leap second. The last leap second was 2016-12-31, so this issue has almost no impact, but still good to fix.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  cxotime git:(fix-fast-convert-leap-sec) git rev-parse --short HEAD                   
c7d7cbe
(ska3) ➜  cxotime git:(fix-fast-convert-leap-sec) pytest
================================================== test session starts ===================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 290 items                                                                                                      

cxotime/tests/test_cxotime.py .................................................................................... [ 28%]
.................................................................................................................. [ 68%]
.............................................................................                                      [ 94%]
cxotime/tests/test_cxotime_linspace.py ...............                                                             [100%]

================================================== 290 passed in 2.47s ===================================================
```

Independent check of unit tests by Jean
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
c7d7cbe865ce9491d02c58550ebf0d1f5d40348a
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 290 items                                                                                                       

cxotime/tests/test_cxotime.py .......................................... [ 14%]
........................................................................ [ 39%]
........................................................................ [ 64%]
........................................................................ [ 88%]
.................                                                                                                   [ 94%]
cxotime/tests/test_cxotime_linspace.py ...............                                                              [100%]

=================================================== 290 passed in 5.58
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
New unit test.
