### PR TITLE
Stop setting copy to False by default

### DIFF
--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -133,15 +133,15 @@ class CxoTime(Time):
 
         if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
             # If input is already a CxoTime instance and no other kwargs just return
-            # the instance. Note that copy=False is the default.
+            # the instance.
             return args[0]
 
         return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
-            # If input is already a CxoTime instance and no other kwargs (which
-            # implies copy=False) then no other initialization is needed.
+            # If input is already a CxoTime instance and no other kwargs
+            # then no other initialization is needed.
             return
 
         if len(args) == 1 and (args[0] is None or args[0] is CxoTime.NOW):
@@ -181,8 +181,6 @@ class CxoTime(Time):
         if fmt is None and len(args) == 1:
             kwargs_orig = copy(kwargs)
             kwargs["scale"] = "utc"
-            # Do not make a copy unless specifically set by user
-            kwargs.setdefault("copy", False)
             # Convert to np.array at this point to get dtype
             val = np.asarray(args[0])
 

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -140,8 +140,8 @@ class CxoTime(Time):
 
     def __init__(self, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
-            # If input is already a CxoTime instance and no other kwargs
-            # then no other initialization is needed.
+            # If input is already a CxoTime instance and no other kwargs (which
+            # implies copy only if needed) then no other initialization is needed.
             return
 
         if len(args) == 1 and (args[0] is None or args[0] is CxoTime.NOW):

--- a/cxotime/cxotime.py
+++ b/cxotime/cxotime.py
@@ -133,7 +133,8 @@ class CxoTime(Time):
 
         if len(args) == 1 and isinstance(args[0], CxoTime) and not kwargs:
             # If input is already a CxoTime instance and no other kwargs just return
-            # the instance.
+            # the instance. Note that copy only if needed is the default, so returning
+            # the original here is expected.
             return args[0]
 
         return super().__new__(cls, *args, **kwargs)


### PR DESCRIPTION
## Description

Don't set default of copy=False in `__init__`.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
In numpy > 2 the copy=False default causes an error if the operation cannot be done without a copy.  In numpy < 2.0 this was benign as copy=False was equivalent to "copy if you have to".  But changing to not set the default appears to be benign in ska with numpy < 2.0 and the astropy Time default was already to not-copy so a change here appears to be non-impacting.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac on ska3-latest (numpy < 2)
```
(latest) flame:cxotime jean$ git rev-parse HEAD
59d104b70102f4ea55c14969aa65edfcef33b3f2
(latest) flame:cxotime jean$ pytest
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 292 items                                                            

cxotime/tests/test_cxotime.py .......................................... [ 14%]
........................................................................ [ 39%]
........................................................................ [ 63%]
........................................................................ [ 88%]
...................                                                                                                                                       [ 94%]
cxotime/tests/test_cxotime_linspace.py ...............                                                                                                    [100%]

====================================================================== 292 passed in 1.63s
```


Independent check of unit tests by Javier
- [x] OSX:
```
(ska3-flight-2026.0rc4) ~/SAO/git/cxotime unset-copy-default $ git rev-parse HEAD       
a00bd8e183b26a8783cc350615376a15242b304f
(ska3-flight-2026.0rc4) ~/SAO/git/cxotime unset-copy-default $ pytest cxotime           
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 292 items                                                                                                                                          

cxotime/tests/test_cxotime.py ........................................................................................................................ [ 41%]
...................................................................................................................................................... [ 92%]
.......                                                                                                                                                [ 94%]
cxotime/tests/test_cxotime_linspace.py ...............                                                                                                 [100%]

==================================================================== 292 passed in 1.52s =====================================================================
(ska3-flight-2026.0rc4) ~/SAO/git/cxotime unset-copy-default $ conda deactivate                    
(ska3-flight) ~/SAO/git/cxotime unset-copy-default $ pytest cxotime  
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 292 items                                                                                                                                          

cxotime/tests/test_cxotime.py ........................................................................................................................ [ 41%]
...................................................................................................................................................... [ 92%]
.......                                                                                                                                                [ 94%]
cxotime/tests/test_cxotime_linspace.py ...............                                                                                                 [100%]

==================================================================== 292 passed in 1.60s =====================================================================

```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
